### PR TITLE
Improve readability of Bible Family Tree nodes

### DIFF
--- a/projects/BibleFamilyTree/app.js
+++ b/projects/BibleFamilyTree/app.js
@@ -112,7 +112,7 @@ function updateTree() {
         });
 
     nodeEnter.append('circle')
-        .attr('r', 5);
+        .attr('r', 8);
 
     nodeEnter.append('title')
         .text(d => d.data.references ? d.data.references.join(', ') : '');

--- a/projects/BibleFamilyTree/style.css
+++ b/projects/BibleFamilyTree/style.css
@@ -19,6 +19,10 @@
 
 .node text {
     fill: var(--text-color);
+    font-size: 14px;
+    stroke: var(--bg-color);
+    stroke-width: 2px;
+    paint-order: stroke fill;
 }
 
 .link {


### PR DESCRIPTION
## Summary
- add outlines and bigger font on tree text labels
- enlarge node circles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6879c8d352d08329a17376a3e678b7a0