### PR TITLE
Add pediatric dermatology MediCards deck

### DIFF
--- a/projects/MediCards/PediatricDermatology/index.html
+++ b/projects/MediCards/PediatricDermatology/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MediCards | Pediatric Dermatology</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <header class="page-header">
+    <h1>MediCards</h1>
+    <p class="page-subtitle">Pediatric Dermatology Flash Cards</p>
+  </header>
+
+  <main class="layout">
+    <section class="controls" aria-label="Deck controls">
+      <div class="control-group">
+        <label for="cardSelector">Jump to card</label>
+        <select id="cardSelector" aria-label="Select a card"></select>
+      </div>
+      <div class="control-group">
+        <button id="prevCard" class="nav-button" type="button">&#9664; Previous</button>
+        <button id="nextCard" class="nav-button" type="button">Next &#9654;</button>
+      </div>
+      <div class="control-group">
+        <button id="randomCard" type="button">Surprise Me</button>
+        <button id="flipCard" type="button">Flip</button>
+        <button id="toggleExplanation" type="button">Explanation</button>
+      </div>
+      <div class="control-group">
+        <button id="readAloud" type="button" aria-live="polite">Read Aloud</button>
+      </div>
+    </section>
+
+    <section class="card-stage" aria-live="polite">
+      <div class="card-wrapper">
+        <div class="card" id="flashCard">
+          <div class="card-inner" id="cardInner">
+            <article class="card-face card-front" id="cardQuestion" aria-label="Question"></article>
+            <article class="card-face card-back" id="cardAnswer" aria-label="Answer"></article>
+          </div>
+        </div>
+        <p class="card-count" id="cardCount"></p>
+      </div>
+    </section>
+
+    <aside class="explanation-panel" id="explanationPanel" hidden>
+      <h2>Deeper Dive</h2>
+      <p id="explanationText"></p>
+      <div id="sources"></div>
+    </aside>
+  </main>
+
+  <footer class="page-footer">
+    <p>Built for rapid clinical refreshers &mdash; switch decks by loading a different specialization.</p>
+  </footer>
+
+  <script src="pediatric-dermatology.js" defer></script>
+  <script src="mediCards.js" defer></script>
+</body>
+</html>

--- a/projects/MediCards/PediatricDermatology/mediCards.js
+++ b/projects/MediCards/PediatricDermatology/mediCards.js
@@ -1,0 +1,186 @@
+(function () {
+  const deck = window.mediCardsDeck;
+  if (!deck || !Array.isArray(deck.cards) || deck.cards.length === 0) {
+    console.error('No cards found for this deck. Ensure the data file defines window.mediCardsDeck.');
+    return;
+  }
+
+  let currentIndex = 0;
+  const cardWrapper = document.querySelector('.card-wrapper');
+  const cardElement = document.getElementById('flashCard');
+  const questionEl = document.getElementById('cardQuestion');
+  const answerEl = document.getElementById('cardAnswer');
+  const cardCountEl = document.getElementById('cardCount');
+  const explanationPanel = document.getElementById('explanationPanel');
+  const explanationText = document.getElementById('explanationText');
+  const sourcesContainer = document.getElementById('sources');
+
+  const selector = document.getElementById('cardSelector');
+  const prevBtn = document.getElementById('prevCard');
+  const nextBtn = document.getElementById('nextCard');
+  const randomBtn = document.getElementById('randomCard');
+  const flipBtn = document.getElementById('flipCard');
+  const explanationBtn = document.getElementById('toggleExplanation');
+  const readBtn = document.getElementById('readAloud');
+
+  const speechSupported = 'speechSynthesis' in window;
+
+  function populateSelector() {
+    selector.innerHTML = '';
+    deck.cards.forEach((card, index) => {
+      const option = document.createElement('option');
+      option.value = index;
+      option.textContent = `${index + 1}. ${card.shortLabel || card.title}`;
+      selector.appendChild(option);
+    });
+  }
+
+  function applyCardContent(card) {
+    questionEl.innerHTML = `
+      <h2>${card.title}</h2>
+      <div class="card-content">${card.question}</div>
+    `;
+
+    answerEl.innerHTML = `
+      <h2>Answer</h2>
+      <div class="card-content">${card.answer}</div>
+    `;
+
+    explanationText.innerHTML = card.explanation;
+    renderSources(card.sources || []);
+    cardCountEl.textContent = `Card ${currentIndex + 1} of ${deck.cards.length}`;
+    selector.value = String(currentIndex);
+  }
+
+  function renderSources(sources) {
+    if (!sources.length) {
+      sourcesContainer.innerHTML = '';
+      sourcesContainer.hidden = true;
+      return;
+    }
+
+    const listItems = sources
+      .map(
+        (source) =>
+          `<li><a href="${source.url}" target="_blank" rel="noopener noreferrer">${source.label}</a></li>`
+      )
+      .join('');
+
+    sourcesContainer.innerHTML = `
+      <h3>Sources</h3>
+      <ul>${listItems}</ul>
+    `;
+    sourcesContainer.hidden = false;
+  }
+
+  function goToCard(index) {
+    const normalizedIndex = (index + deck.cards.length) % deck.cards.length;
+    currentIndex = normalizedIndex;
+    cardWrapper.classList.remove('transitioning');
+    void cardWrapper.offsetWidth; // trigger reflow for animation restart
+    cardWrapper.classList.add('transitioning');
+    cardElement.classList.remove('is-flipped');
+    explanationPanel.hidden = true;
+    explanationBtn.textContent = 'Explanation';
+    applyCardContent(deck.cards[currentIndex]);
+  }
+
+  function nextCard() {
+    goToCard(currentIndex + 1);
+  }
+
+  function previousCard() {
+    goToCard(currentIndex - 1);
+  }
+
+  function randomCard() {
+    if (deck.cards.length <= 1) {
+      return;
+    }
+    let newIndex = currentIndex;
+    while (newIndex === currentIndex) {
+      newIndex = Math.floor(Math.random() * deck.cards.length);
+    }
+    goToCard(newIndex);
+  }
+
+  function flipCard() {
+    cardElement.classList.toggle('is-flipped');
+  }
+
+  function toggleExplanation() {
+    const isHidden = explanationPanel.hidden;
+    explanationPanel.hidden = !isHidden;
+    if (!isHidden) {
+      explanationBtn.textContent = 'Explanation';
+    } else {
+      explanationBtn.textContent = 'Hide Explanation';
+    }
+  }
+
+  function speakCard() {
+    if (!speechSupported) {
+      readBtn.disabled = true;
+      readBtn.textContent = 'Speech not supported';
+      return;
+    }
+
+    window.speechSynthesis.cancel();
+    const card = deck.cards[currentIndex];
+    const utterance = new SpeechSynthesisUtterance();
+    utterance.text = `${card.title}. Question: ${stripHtml(card.question)}. Answer: ${stripHtml(
+      card.answer
+    )}`;
+    utterance.lang = 'en-US';
+    utterance.rate = 1;
+    window.speechSynthesis.speak(utterance);
+  }
+
+  function stripHtml(html) {
+    const temp = document.createElement('div');
+    temp.innerHTML = html;
+    return temp.textContent || temp.innerText || '';
+  }
+
+  populateSelector();
+  goToCard(0);
+
+  if (!speechSupported) {
+    readBtn.disabled = true;
+    readBtn.textContent = 'Speech not supported';
+  }
+
+  selector.addEventListener('change', (event) => {
+    goToCard(Number(event.target.value));
+  });
+  prevBtn.addEventListener('click', previousCard);
+  nextBtn.addEventListener('click', nextCard);
+  randomBtn.addEventListener('click', randomCard);
+  flipBtn.addEventListener('click', flipCard);
+  cardElement.addEventListener('click', flipCard);
+  explanationBtn.addEventListener('click', toggleExplanation);
+  if (speechSupported) {
+    readBtn.addEventListener('click', speakCard);
+  }
+
+  document.addEventListener('keydown', (event) => {
+    switch (event.key) {
+      case 'ArrowLeft':
+        previousCard();
+        break;
+      case 'ArrowRight':
+        nextCard();
+        break;
+      case ' ':
+        event.preventDefault();
+        flipCard();
+        break;
+      case 'r':
+      case 'R':
+        randomCard();
+        break;
+      default:
+        break;
+    }
+  });
+})();

--- a/projects/MediCards/PediatricDermatology/pediatric-dermatology.js
+++ b/projects/MediCards/PediatricDermatology/pediatric-dermatology.js
@@ -1,0 +1,233 @@
+window.mediCardsDeck = {
+  deckName: 'Pediatric Dermatology',
+  cards: [
+    {
+      title: 'Atopic Dermatitis (Eczema)',
+      shortLabel: 'Atopic dermatitis',
+      question:
+        '<strong>Presentation:</strong> Pruritic, xerotic patches that begin on infant cheeks/extensors and later favor flexures.<br><br>What is the skin-directed, stepwise treatment plan for a flare?',
+      answer:
+        '<ul><li>Daily lukewarm baths with gentle cleansers, followed by liberal emollients; consider wet wraps.</li><li>Topical anti-inflammatories by site/age: low-to-mid potency steroids, or calcineurin inhibitors for delicate areas.</li><li>Escalate to ruxolitinib 1.5% cream (≥2 years, non-immunocompromised) or other systemic therapy if refractory.</li><li>Add dilute bleach baths and targeted antimicrobials only when secondary infection is present.</li></ul>',
+      explanation:
+        '<p>Atopic dermatitis in children is usually clinical. Therapy begins with barrier repair and short lukewarm bathing, layering emollients immediately afterward. Match steroid potency to body site and age, reserving calcineurin inhibitors for the face, folds, and maintenance. Recent FDA action allows ruxolitinib cream down to age 2 in non-immunocompromised patients. Bacterial swabs and antibiotics are reserved for evident infection, while bleach baths help prevent recurrence. Escalate care for uncontrolled disease that impairs sleep, growth, or psychosocial wellbeing.</p>',
+      sources: [
+        {
+          label: 'American Academy of Pediatrics – Treatment of Atopic Dermatitis',
+          url: 'https://www.aap.org/en/patient-care/atopic-dermatitis/treatment-of-atopic-dermatitis/?utm_source=chatgpt.com'
+        },
+        {
+          label: 'AAAAI 2023 Atopic Dermatitis Guideline',
+          url: 'https://www.aaaai.org/Aaaai/media/Media-Library-PDFs/Allergist%20Resources/Statements%20and%20Practice%20Parameters/JTF-Atopic-Dermatitis-Guideline-2023-07-31-2026.pdf?utm_source=chatgpt.com'
+        },
+        {
+          label: 'FDA expands Opzelura approval to ages 2–11',
+          url: 'https://www.managedhealthcareexecutive.com/view/fda-expands-approval-of-opzelura-cream-to-children-ages-2-to-11-with-atopic-dermatitis?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Diaper Dermatitis',
+      shortLabel: 'Diaper rash',
+      question:
+        '<strong>Presentation:</strong> Beefy erythema across convex diaper surfaces; satellite papules or pustules imply Candida.<br><br>Which bedside treatments are first-line, and when do you add medications?',
+      answer:
+        '<ul><li>Frequent diaper changes, open-air time, and thick zinc oxide or petrolatum barrier with every change.</li><li>Apply topical azole (miconazole or clotrimazole) if Candida is suspected.</li><li>Use a short course of low-potency steroid (hydrocortisone 1%–2.5%) for significant inflammation, avoiding stronger agents under occlusion.</li></ul>',
+      explanation:
+        '<p>Classic irritant diaper dermatitis spares the inguinal folds, whereas Candida involvement brings maceration and satellite lesions. Management centers on moisture control and barrier protection. A topical azole targets yeast when KOH or clinical cues point to Candida. Brief, low-potency topical steroids can calm inflammation but higher potencies risk atrophy under occlusion.</p>',
+      sources: [
+        {
+          label: 'American Academy of Pediatrics – Diaper Rash',
+          url: 'https://publications.aap.org/pediatriccare/article/doi/10.1542/aap.ppcqr.396155/1621/Diaper-Rash?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Impetigo',
+      shortLabel: 'Impetigo basics',
+      question:
+        '<strong>Presentation:</strong> Honey-colored crusts (nonbullous) or flaccid bullae.<br><br>How do you choose between topical and systemic therapy?',
+      answer:
+        '<ul><li>For limited lesions, prescribe topical mupirocin or retapamulin for 5 days.</li><li>Use oral therapy (e.g., cephalexin) when lesions are numerous, there is an outbreak, or systemic features exist; tailor to local MRSA prevalence.</li><li>Consider culture for outbreaks, treatment failure, or diagnostic uncertainty.</li></ul>',
+      explanation:
+        '<p>Impetigo is usually clinical, driven by <em>S. aureus</em> or group A strep. Localized disease responds well to topical agents, reducing systemic exposure. Multiple lesions, school outbreaks, or failure of topicals warrant an oral β-lactam, with MRSA-active choices when risk is high. While rare, families should be counseled about post-streptococcal glomerulonephritis as a delayed complication.</p>',
+      sources: [
+        {
+          label: 'CDC – Clinical Guidance for Impetigo',
+          url: 'https://www.cdc.gov/group-a-strep/hcp/clinical-guidance/impetigo.html?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Tinea Infections',
+      shortLabel: 'Tinea patterns',
+      question:
+        '<strong>Presentation:</strong> Annular plaques with leading scale (corporis/pedis) or patchy alopecia with scale and kerion (capitis).<br><br>Which diagnostics and treatments are most reliable for kids?',
+      answer:
+        '<ul><li>Confirm with KOH scraping; send fungal culture for scalp disease or atypical cases.</li><li>Treat corporis/pedis with topical allylamine or azole; avoid steroid combinations.</li><li>For tinea capitis, prescribe systemic therapy (griseofulvin 20–25 mg/kg/day microsize for 6–8 weeks or weight-based terbinafine) plus antifungal shampoo to limit shedding.</li></ul>',
+      explanation:
+        '<p>Dermatophyte infections mimic eczema, so bedside microscopy is valuable. Topicals suffice for corporis/pedis but not capitis, where follicles harbor fungus. Griseofulvin remains effective, especially for <em>Microsporum</em>, while terbinafine is favored for <em>Trichophyton</em>. Adjunctive selenium sulfide or ketoconazole shampoo reduces spore transmission during the first two treatment weeks.</p>',
+      sources: [
+        {
+          label: 'American Academy of Family Physicians – Common Tinea Infections',
+          url: 'https://www.aafp.org/pubs/afp/issues/2008/0515/p1415.html?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Scabies',
+      shortLabel: 'Scabies essentials',
+      question:
+        '<strong>Presentation:</strong> Intense nocturnal pruritus with papules and burrows on wrists, finger webs, waistline, or scalp in infants.<br><br>Describe the recommended treatment course and household precautions.',
+      answer:
+        '<ul><li>Apply permethrin 5% cream to the entire body (include scalp/face in infants), leave on 8–14 hours, and repeat in 7 days; FDA-approved for ages ≥2 months.</li><li>Treat close contacts simultaneously and decontaminate linens and clothing (hot wash/dry or seal for 3 days).</li><li>Consider mineral oil scraping or dermoscopy for confirmation when the diagnosis is uncertain.</li></ul>',
+      explanation:
+        '<p>Clinical history of family-wide itch is often enough to begin therapy. Proper application includes finger/toe webs, under nails, and post-bath when skin is cool. Reinfection is common without simultaneous contact treatment and environmental precautions. Post-scabetic pruritus can persist for weeks—reassure families and manage with emollients or mild steroids.</p>',
+      sources: [
+        {
+          label: 'CDC – Clinical Care of Scabies',
+          url: 'https://www.cdc.gov/scabies/hcp/clinical-care/index.html?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Molluscum Contagiosum',
+      shortLabel: 'Molluscum',
+      question:
+        '<strong>Presentation:</strong> Umbilicated, skin-colored papules often clustered in atopic children.<br><br>When is active treatment indicated, and what are the options?',
+      answer:
+        '<ul><li>Watchful waiting is reasonable because lesions spontaneously resolve over months to years.</li><li>Treat when lesions are numerous, spreading, symptomatic, genital, or causing distress.</li><li>Clinic options include cantharidin (FDA-approved ≥2 years), curettage, cryotherapy, or other office-directed modalities.</li></ul>',
+      explanation:
+        '<p>Molluscum is benign yet bothersome, especially in children with atopic dermatitis who auto-inoculate through scratching. Shared decision-making helps decide between observation and procedures. When treating, protect surrounding skin, manage secondary eczema, and counsel on avoiding picking or sharing towels to prevent spread.</p>',
+      sources: [
+        {
+          label: 'Texas Children’s – Molluscum Contagiosum Guidelines',
+          url: 'https://www.texaschildrens.org/sites/default/files/uploads/molluscum%20contagiosum_0.pdf?utm_source=chatgpt.com'
+        },
+        {
+          label: 'FDA – Ycanth (Cantharidin) Label',
+          url: 'https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/212905s000lbl.pdf?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Hand-Foot-Mouth Disease',
+      shortLabel: 'HFMD',
+      question:
+        '<strong>Presentation:</strong> Low-grade fever, painful oral ulcers, and vesicles on hands, feet, and buttocks.<br><br>What supportive care guidance should families receive?',
+      answer:
+        '<ul><li>Encourage hydration and offer pain control (acetaminophen/ibuprofen as age-appropriate).</li><li>Reassure that most children may return to daycare/school once afebrile, feeling well, and drooling is controlled.</li><li>Viral testing is rarely needed; focus on symptomatic management.</li></ul>',
+      explanation:
+        '<p>HFMD is a self-limited enteroviral illness. The main risks are dehydration from painful stomatitis and discomfort-related sleep disruption. Educate caregivers about typical illness duration (7–10 days), hand hygiene, and red flags such as persistent fever, neurologic symptoms, or inability to maintain oral intake.</p>',
+      sources: [
+        {
+          label: 'CDC – Hand, Foot, and Mouth Disease Overview',
+          url: 'https://www.cdc.gov/hand-foot-mouth/about/index.html?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Seborrheic Dermatitis (Cradle Cap)',
+      shortLabel: 'Cradle cap',
+      question:
+        '<strong>Presentation:</strong> Greasy scale or crust on the infant scalp with minimal itch and a well-appearing baby.<br><br>Which home treatments do you recommend, and when do you escalate?',
+      answer:
+        '<ul><li>Advise gentle daily shampooing, softening scales with mineral oil or petrolatum, then brushing to lift debris.</li><li>If persistent or extensive, add ketoconazole 2% cream or shampoo.</li><li>Reassure families that the condition is benign and self-limited.</li></ul>',
+      explanation:
+        '<p>Cradle cap reflects sebaceous activity and Malassezia colonization in infants. Moisturizing the scalp before combing loosens adherent scale. Antifungal therapy is rarely necessary but effective for widespread or refractory disease. Lack of inflammation or systemic symptoms helps distinguish it from eczema or psoriasis.</p>',
+      sources: [
+        {
+          label: 'HealthyChildren.org – What is Cradle Cap?',
+          url: 'https://www.healthychildren.org/English/ages-stages/baby/bathing-skin-care/Pages/Cradle-Cap.aspx?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Infantile Hemangioma',
+      shortLabel: 'Infantile hemangioma',
+      question:
+        '<strong>Presentation:</strong> Rapidly growing vascular plaque/nodule in the first months of life.<br><br>Which lesions warrant early referral and what is the frontline therapy?',
+      answer:
+        '<ul><li>Refer urgently if the lesion threatens function (eye, airway), is ulcerated, large facial/segmental, or high risk for disfigurement.</li><li>Oral propranolol (2–3 mg/kg/day divided) is first-line for high-risk infantile hemangiomas per AAP guideline.</li><li>Topical timolol can be considered for small superficial lesions.</li></ul>',
+      explanation:
+        '<p>Infantile hemangiomas proliferate rapidly between 1 and 3 months; early risk stratification prevents functional compromise and scarring. Systemic propranolol, started ideally before 5 months of age, accelerates involution and minimizes complications. Imaging is reserved for segmental patterns, airway involvement, or when diagnosis is uncertain.</p>',
+      sources: [
+        {
+          label: 'AAP Guideline – Management of Infantile Hemangiomas',
+          url: 'https://publications.aap.org/pediatrics/article/143/1/e20183475/37268/Clinical-Practice-Guideline-for-the-Management-of?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Acne (Preadolescent & Adolescent)',
+      shortLabel: 'Acne plan',
+      question:
+        '<strong>Presentation:</strong> Comedones with inflammatory papules/pustules; evaluate for endocrine clues in prepubertal patients.<br><br>Outline the evidence-based treatment ladder.',
+      answer:
+        '<ul><li>Mild disease: topical benzoyl peroxide ± topical retinoid; add topical antibiotic only in combination with benzoyl peroxide.</li><li>Moderate to severe: continue topicals and add oral doxycycline or minocycline for limited courses.</li><li>Severe, scarring, or refractory cases: consider oral isotretinoin and dermatology referral.</li></ul>',
+      explanation:
+        '<p>Combination topical therapy targets follicular keratinization and inflammation. Oral antibiotics reduce inflammatory lesions but should be paired with benzoyl peroxide to deter resistance and limited to about 3 months. Hormonal modulation (combined oral contraceptives or spironolactone) supports female patients when age-appropriate. Early isotretinoin prevents scarring in nodulocystic acne.</p>',
+      sources: [
+        {
+          label: 'JAAD – Guidelines for Acne Management',
+          url: 'https://www.jaad.org/article/S0190-9622%2823%2903389-3/fulltext?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Psoriasis (Pediatric)',
+      shortLabel: 'Pediatric psoriasis',
+      question:
+        '<strong>Presentation:</strong> Well-demarcated erythematous plaques with silvery scale on scalp, trunk, and extensor surfaces.<br><br>What are the cornerstones of management for children?',
+      answer:
+        '<ul><li>Topical corticosteroids paired with vitamin D analogs; use calcineurin inhibitors for face/genitals.</li><li>Monitor for psoriatic arthritis symptoms and avoid prolonged high-potency steroid use.</li><li>Escalate to phototherapy or systemic agents for moderate-to-severe or refractory disease in collaboration with dermatology.</li></ul>',
+      explanation:
+        '<p>Pediatric psoriasis impacts quality of life and carries joint involvement risk. Combination topical regimens balance efficacy with steroid-sparing benefits. Persistent or widespread disease may require narrowband UVB, methotrexate, biologics, or other systemic therapy guided by specialists.</p>',
+      sources: [
+        {
+          label: 'JAAD/NPF – Pediatric Psoriasis Guidelines',
+          url: 'https://www.jaad.org/article/S0190-9622%2819%2932655-6/fulltext?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Urticaria (Acute)',
+      shortLabel: 'Acute urticaria',
+      question:
+        '<strong>Presentation:</strong> Transient, itchy wheals with or without angioedema; always assess for anaphylaxis.<br><br>How do you control symptoms and counsel families?',
+      answer:
+        '<ul><li>Start second-generation oral H1 antihistamines (cetirizine, loratadine, fexofenadine) and titrate to control.</li><li>Reserve short corticosteroid bursts for severe, refractory cases.</li><li>Administer intramuscular epinephrine immediately if anaphylaxis signs are present.</li></ul>',
+      explanation:
+        '<p>Acute urticaria often follows infections, foods, or medications and resolves within days to weeks. Non-sedating antihistamines are preferred for daytime use and can be dosed up to fourfold in older children under supervision. Educate caregivers about triggers, anaphylaxis warning signs, and the generally self-limited course.</p>',
+      sources: [
+        {
+          label: 'AAP Pediatrics in Review – Urticaria, Angioedema, and Anaphylaxis',
+          url: 'https://publications.aap.org/pediatricsinreview/article/41/6/283/35410/Urticaria-Angioedema-and-Anaphylaxis?utm_source=chatgpt.com'
+        }
+      ]
+    },
+    {
+      title: 'Fast Diagnostic Clues',
+      shortLabel: 'Rapid tests',
+      question:
+        '<strong>Scenario:</strong> You are triaging rashes in clinic.<br><br>Which quick tests help separate look-alike diagnoses?',
+      answer:
+        '<ul><li>KOH prep distinguishes dermatophyte infections from eczema or psoriasis.</li><li>Bacterial culture supports management of widespread or refractory impetigo.</li><li>Mineral oil scraping or dermoscopy can document scabies mites, eggs, or scybala.</li></ul>',
+      explanation:
+        '<p>Judicious bedside testing streamlines management without over-ordering labs. A KOH scraping highlights branching hyphae of tinea, while cultures refine antibiotic choice for impetigo. Although scabies remains a clinical diagnosis, identifying mites or ova helps families commit to thorough decontamination and simultaneous treatment of contacts.</p>',
+      sources: [
+        {
+          label: 'AAFP – Diagnosis and Management of Tinea Infections',
+          url: 'https://www.aafp.org/pubs/afp/issues/2014/1115/p702.html?utm_source=chatgpt.com'
+        },
+        {
+          label: 'CDC – Clinical Guidance for Impetigo',
+          url: 'https://www.cdc.gov/group-a-strep/hcp/clinical-guidance/impetigo.html?utm_source=chatgpt.com'
+        },
+        {
+          label: 'CDC – Clinical Care of Scabies',
+          url: 'https://www.cdc.gov/scabies/hcp/clinical-care/index.html?utm_source=chatgpt.com'
+        }
+      ]
+    }
+  ]
+};

--- a/projects/MediCards/PediatricDermatology/styles.css
+++ b/projects/MediCards/PediatricDermatology/styles.css
@@ -1,0 +1,286 @@
+:root {
+  --bg: #0f172a;
+  --surface: #111c3d;
+  --surface-alt: #162551;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --success: #4ade80;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 50%),
+    linear-gradient(160deg, #0f172a 0%, #0b1224 55%, #050816 100%);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding: 2rem 1rem 1rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.page-subtitle {
+  margin-top: 0.5rem;
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.5rem;
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  flex: 1 0 auto;
+  padding-bottom: 3rem;
+}
+
+.controls {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  backdrop-filter: blur(18px);
+}
+
+.control-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+label {
+  font-weight: 600;
+}
+
+select,
+button {
+  font: inherit;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 0.65rem 1.35rem;
+  background: var(--surface-alt);
+  color: var(--text);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+select:focus,
+button:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.25);
+}
+
+button:hover,
+select:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+button.nav-button {
+  background: linear-gradient(145deg, rgba(56, 189, 248, 0.15), rgba(14, 165, 233, 0.3));
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.card-stage {
+  display: flex;
+  justify-content: center;
+}
+
+.card-wrapper {
+  perspective: 1800px;
+  width: min(600px, 88vw);
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.card {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  position: relative;
+  border-radius: 26px;
+  overflow: hidden;
+  box-shadow: 0 18px 45px rgba(2, 6, 23, 0.55);
+}
+
+.card-inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 640ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.card.is-flipped .card-inner {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  padding: clamp(1.25rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: linear-gradient(165deg, rgba(17, 28, 61, 0.82), rgba(13, 20, 45, 0.95));
+}
+
+.card-front {
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.18), rgba(17, 28, 61, 0.9));
+}
+
+.card-back {
+  transform: rotateY(180deg);
+  background: linear-gradient(160deg, rgba(74, 222, 128, 0.18), rgba(17, 28, 61, 0.9));
+}
+
+.card-front h2,
+.card-back h2 {
+  margin-top: 0;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.card-content {
+  margin-top: 0.75rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.card-count {
+  margin: 0;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.explanation-panel {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  backdrop-filter: blur(14px);
+  line-height: 1.65;
+  animation: slide-up 420ms ease;
+}
+
+.explanation-panel h2 {
+  margin-top: 0;
+}
+
+#sources {
+  margin-top: 1rem;
+}
+
+#sources h3 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+#sources ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+}
+
+#sources a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+#sources a:hover {
+  text-decoration: underline;
+}
+
+.page-footer {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.card-wrapper.transitioning {
+  animation: float-in 520ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@keyframes float-in {
+  0% {
+    transform: translateY(28px) scale(0.98);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-up {
+  0% {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(260px, 320px);
+    align-items: start;
+  }
+
+  .controls {
+    position: sticky;
+    top: 1.5rem;
+  }
+
+  .explanation-panel {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .controls {
+    padding: 1.25rem;
+  }
+
+  button,
+  select {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .control-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- create a pediatric dermatology MediCards page with navigation, flip animations, and explanation drawer
- add reusable MediCards logic with text-to-speech support and random/sequential navigation
- author a pediatric dermatology question deck with linked sources for each explanation

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9d96e7a38832995d9553cb41797b8