### PR TITLE
Improve MediCards mobile layout

### DIFF
--- a/projects/MediCards/PediatricDermatology/index.html
+++ b/projects/MediCards/PediatricDermatology/index.html
@@ -17,7 +17,18 @@
   </header>
 
   <main class="layout">
-    <section class="controls" aria-label="Deck controls">
+    <button
+      class="controls-toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls="deckControls"
+      data-controls-toggle
+      data-label-open="Hide deck controls"
+      data-label-closed="Show deck controls"
+    >
+      Show deck controls
+    </button>
+    <section class="controls" id="deckControls" aria-label="Deck controls">
       <div class="control-section">
         <h2 class="control-title">Browse topics</h2>
         <label for="sectionSelector" class="control-label">Topic group</label>

--- a/projects/MediCards/PediatricDermatology/mediCards.js
+++ b/projects/MediCards/PediatricDermatology/mediCards.js
@@ -39,6 +39,70 @@ function disableInterface(disabled) {
   });
 }
 
+function setupControlsToggle() {
+  const toggle = document.querySelector('[data-controls-toggle]');
+  const controls = document.getElementById('deckControls');
+
+  if (!toggle || !controls) {
+    return;
+  }
+
+  toggle.classList.add('is-visible');
+
+  const mobileQuery = window.matchMedia('(max-width: 959px)');
+  const openLabel = toggle.dataset.labelOpen || 'Hide deck controls';
+  const closedLabel = toggle.dataset.labelClosed || 'Show deck controls';
+
+  let isMobile = mobileQuery.matches;
+  let isExpandedOnMobile = false;
+
+  const update = (expanded) => {
+    toggle.setAttribute('aria-expanded', String(expanded));
+    toggle.textContent = expanded ? openLabel : closedLabel;
+
+    if (isMobile) {
+      controls.hidden = !expanded;
+    } else {
+      controls.hidden = false;
+    }
+  };
+
+  const handleViewportChange = () => {
+    isMobile = mobileQuery.matches;
+    if (isMobile) {
+      update(isExpandedOnMobile);
+    } else {
+      update(true);
+    }
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    const nextState = !expanded;
+
+    if (isMobile) {
+      isExpandedOnMobile = nextState;
+    }
+
+    update(nextState);
+
+    if (nextState && isMobile) {
+      const firstInteractive = controls.querySelector('select, button');
+      if (firstInteractive) {
+        firstInteractive.focus();
+      }
+    }
+  });
+
+  if (typeof mobileQuery.addEventListener === 'function') {
+    mobileQuery.addEventListener('change', handleViewportChange);
+  } else if (typeof mobileQuery.addListener === 'function') {
+    mobileQuery.addListener(handleViewportChange);
+  }
+
+  handleViewportChange();
+}
+
 function showDeckLoadError(message) {
   disableInterface(true);
   setStatusMessage(message);
@@ -764,6 +828,7 @@ class DeckController {
 }
 
 (async function initialiseDeck() {
+  setupControlsToggle();
   setStatusMessage('Loading pediatric dermatology cards...');
 
   try {

--- a/projects/MediCards/PediatricDermatology/styles.css
+++ b/projects/MediCards/PediatricDermatology/styles.css
@@ -62,6 +62,11 @@ body {
 .layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    'stage'
+    'toggle'
+    'controls'
+    'explanation';
   gap: 1.5rem;
   width: min(1200px, 92vw);
   margin: 0 auto;
@@ -69,7 +74,36 @@ body {
   padding-bottom: 3rem;
 }
 
+.controls-toggle {
+  grid-area: toggle;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.controls-toggle:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.25);
+}
+
+.controls-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
 .controls {
+  grid-area: controls;
   background: rgba(15, 23, 42, 0.4);
   border: 1px solid rgba(148, 163, 184, 0.15);
   border-radius: 20px;
@@ -77,6 +111,16 @@ body {
   display: grid;
   gap: 1.25rem;
   backdrop-filter: blur(18px);
+}
+
+.controls[hidden] {
+  display: none !important;
+}
+
+.card-stage {
+  grid-area: stage;
+  display: flex;
+  justify-content: center;
 }
 
 .control-section {
@@ -156,11 +200,6 @@ button.nav-button {
 .controls select {
   width: 100%;
   max-width: 100%;
-}
-
-.card-stage {
-  display: flex;
-  justify-content: center;
 }
 
 .card-wrapper {
@@ -330,6 +369,7 @@ button.nav-button {
 }
 
 .explanation-panel {
+  grid-area: explanation;
   background: rgba(15, 23, 42, 0.55);
   border-radius: 20px;
   padding: 1.5rem;
@@ -407,10 +447,29 @@ button.nav-button {
   }
 }
 
+@media (max-width: 959px) {
+  .layout {
+    gap: 1.25rem;
+  }
+
+  .controls-toggle.is-visible {
+    display: inline-flex;
+  }
+
+  .controls {
+    padding: 1.25rem;
+  }
+}
+
 @media (min-width: 960px) {
   .layout {
     grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(260px, 320px);
+    grid-template-areas: 'controls stage explanation';
     align-items: start;
+  }
+
+  .controls-toggle {
+    display: none;
   }
 
   .controls {

--- a/projects/MediCards/index.html
+++ b/projects/MediCards/index.html
@@ -20,7 +20,7 @@
         Pick a specialization to launch an interactive flashcard deck with rich explanations,
         source links, and text-to-speech accessibility powered by a free cloud narrator.
       </p>
-      <a class="primary-action" href="../.. /projects.html">Back to Projects</a>
+      <a class="primary-action" href="../../projects.html">Back to Projects</a>
     </header>
 
     <main>


### PR DESCRIPTION
## Summary
- add a responsive deck controls toggle so cards load first on mobile
- update deck styles to reorganize the layout and hide controls when collapsed
- fix the MediCards landing page back-link path

## Testing
- Manual - Verified mobile layout in an emulated iPhone viewport

------
https://chatgpt.com/codex/tasks/task_b_68daf35b13e88329ad347354645e4d9a