### PR TITLE
Fix card text bleed during flips

### DIFF
--- a/projects/MediCards/PediatricDermatology/styles.css
+++ b/projects/MediCards/PediatricDermatology/styles.css
@@ -235,6 +235,7 @@ button.nav-button {
   position: absolute;
   inset: 0;
   backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
   padding: clamp(1.25rem, 2.5vw, 2rem);
   display: flex;
   flex-direction: column;
@@ -253,6 +254,7 @@ button.nav-button {
 }
 
 .card-front {
+  transform: rotateY(0deg);
   background: linear-gradient(160deg, rgba(14, 165, 233, 0.18), rgba(17, 28, 61, 0.9));
 }
 


### PR DESCRIPTION
## Summary
- hide the opposite face of MediCards while flipping to prevent text bleed-through
- explicitly keep the front face oriented toward the viewer during 3D rotation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db0449aaf08329b1cdb69e1448029d