### PR TITLE
Adjust mobile MediCards proportions

### DIFF
--- a/projects/MediCards/PediatricDermatology/styles.css
+++ b/projects/MediCards/PediatricDermatology/styles.css
@@ -490,6 +490,10 @@ button.nav-button {
     padding: 1.25rem;
   }
 
+  .card {
+    aspect-ratio: 3 / 2.6;
+  }
+
   .control-row {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- increase the height of MediCards on narrow screens by adjusting their aspect ratio
- reduce the amount of scrolling required to read card content on mobile devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db166d440c83298cdc064643b95318