### PR TITLE
Refresh pediatric allergy and dermatology cards

### DIFF
--- a/projects/MediCards/PediatricDermatology/data/conditions.js
+++ b/projects/MediCards/PediatricDermatology/data/conditions.js
@@ -1,481 +1,583 @@
 const cards = [
   {
-    id: 'condition-acne',
-    title: 'Acne (Preadolescent & Adolescent)',
-    shortLabel: 'Acne',
+    id: 'atopic-dermatitis-overview',
+    title: 'Atopic Dermatitis – Overview',
+    shortLabel: 'Atopic dermatitis (overview)',
     prompt: {
-      lead: 'Clue',
-      text: 'Comedones with inflammatory papules in a teen—what is the guideline-based treatment ladder?'
-    },
-    answerPoints: [
-      { label: 'Mild', text: 'Benzoyl peroxide with or without a topical retinoid; add topical antibiotic only with benzoyl peroxide.' },
-      {
-        label: 'Moderate to severe',
-        text: 'Add oral doxycycline or minocycline for limited duration, always paired with topical benzoyl peroxide.'
-      },
-      {
-        label: 'Severe or scarring',
-        text: 'Consider oral isotretinoin and refer to dermatology; combine oral contraceptives or spironolactone for select females.'
-      }
-    ],
-    answerSummary:
-      'Pair retinoids with benzoyl peroxide, limit antibiotic monotherapy, and escalate to isotretinoin for scarring disease.',
-    imageSearch: {
-      query: 'teen acne treatment benzoyl peroxide',
-      label: 'Search Google Images for acne treatments'
-    },
-    explanation: [
-      'Combination therapy improves efficacy and limits antimicrobial resistance. Reinforce adherence, gentle cleansers, and non-comedogenic moisturizers to support long-term control.'
-    ],
-    sources: [
-      {
-        label: 'JAAD – Guidelines of care for acne vulgaris',
-        url: 'https://www.jaad.org/article/S0190-9622%2823%2903389-3/fulltext?utm_source=chatgpt.com'
-      }
-    ]
-  },
-  {
-    id: 'condition-atopic-presentation',
-    title: 'Atopic Dermatitis: Presentation',
-    shortLabel: 'Atopic dermatitis (presentation)',
-    prompt: {
-      lead: 'Clue',
-      text: 'Itchy eczematous patches in flexures signal which diagnosis, and what exam findings back it up?'
+      lead: 'Classic case',
+      text: 'Infant with chronic, relapsing itchy patches—what history and exam clinch the diagnosis?'
     },
     answerPoints: [
       {
-        label: 'Presentation',
-        text: 'Pruritic, xerotic patches beginning on infant cheeks and extensors then shifting to flexures.'
+        label: 'History',
+        text: 'Pruritus (often worse at night), chronic or relapsing course, age-related distribution (face/extensors in infants, flexures in older children), irritant exposures, infection history, and family atopy.'
       },
-      { label: 'Look for', text: 'Xerosis, lichenification, excoriations, and signs of superinfection.' },
-      { label: 'Testing', text: 'Usually clinical; swab only if crusted or oozing lesions suggest impetigo.' }
+      {
+        label: 'Exam',
+        text: 'Xerosis, erythematous patches or plaques with excoriations and lichenification; monitor for impetiginized honey crusts or oozing.'
+      },
+      {
+        label: 'Testing',
+        text: 'Diagnosis is clinical; obtain bacterial swab when lesions appear infected and reserve allergy testing for clear immediate-type food triggers.'
+      }
     ],
     answerSummary:
-      'Age-specific distribution and barrier breakdown clinch an atopic dermatitis diagnosis without routine labs.',
+      'Chronic itch with age-specific distribution and barrier dysfunction defines atopic dermatitis—labs are unnecessary unless infection or immediate food allergy is suspected.',
     imageSearch: {
-      query: 'atopic dermatitis flexural rash child',
+      query: 'infant atopic dermatitis cheeks flexural eczema',
       label: 'Search Google Images for atopic dermatitis presentation'
     },
     explanation: [
-      'Documenting itch plus chronic relapsing lesions fulfills atopic dermatitis diagnostic criteria. Reserve bacterial cultures for impetiginized areas and monitor growth and sleep to identify severe disease early.'
+      'Document sleep disruption and growth concerns to gauge severity. Early caregiver education on moisturizing routines prevents escalation to systemic therapies.'
     ],
     sources: [
       {
-        label: 'American Academy of Pediatrics – Treatment of Atopic Dermatitis',
-        url: 'https://www.aap.org/en/patient-care/atopic-dermatitis/treatment-of-atopic-dermatitis/?utm_source=chatgpt.com'
+        label: 'American Academy of Pediatrics – Atopic Dermatitis Care',
+        url: 'https://www.aap.org/en/patient-care/atopic-dermatitis/?utm_source=chatgpt.com'
       },
       {
-        label: 'AAAAI 2023 Atopic Dermatitis Guideline',
-        url: 'https://www.aaaai.org/Aaaai/media/Media-Library-PDFs/Allergist%20Resources/Statements%20and%20Practice%20Parameters/JTF-Atopic-Dermatitis-Guideline-2023-07-31-2026.pdf?utm_source=chatgpt.com'
+        label: 'AAAAI/ACAAI Atopic Dermatitis Guideline 2023',
+        url: 'https://www.aaaai.org/Aaaai/media/Media-Library-PDFs/Allergist%20Resources/Statements%20and%20Practice%20Parameters/JTF-Atopic-Dermatitis-Guideline-2023.pdf?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-atopic-therapy',
-    title: 'Atopic Dermatitis: Stepwise Therapy',
-    shortLabel: 'Atopic dermatitis (therapy)',
+    id: 'atopic-dermatitis-management',
+    title: 'Atopic Dermatitis – Comprehensive Management',
+    shortLabel: 'Atopic dermatitis (management)',
     prompt: {
-      lead: 'Management',
-      text: 'Build the stepwise plan for calming an atopic dermatitis flare.'
+      lead: 'Therapy ladder',
+      text: 'How do you calm flares, protect the barrier, and escalate care for difficult atopic dermatitis?'
     },
     answerPoints: [
       {
         label: 'Skin care',
-        text: 'Daily liberal emollients after short lukewarm baths; wet wraps during flares.'
+        text: 'Daily lukewarm baths with gentle cleanser followed by liberal fragrance-free emollients (at least twice daily); add wet wraps during severe flares.'
       },
       {
-        label: 'Topical anti-inflammatories',
-        text: 'Low to mid potency steroids by site and age; add calcineurin inhibitors for delicate areas.'
+        label: 'Anti-inflammatory therapy',
+        text: 'Apply topical steroids matched to site (low potency for face/folds, medium for trunk/extremities) in short bursts; introduce topical calcineurin inhibitors or crisaborole for steroid-sparing maintenance.'
       },
       {
-        label: 'Infection control',
-        text: 'Dilute bleach baths for recurrent infections; reserve systemic or topical antibiotics for clear infection.'
+        label: 'Itch & infection',
+        text: 'Short bedtime sedating antihistamines only when sleep is disrupted. Use topical mupirocin for localized impetigo, systemic anti-staphylococcal antibiotics for widespread infection, and consider bleach baths 2–3 times weekly for recurrent infections.'
       },
       {
-        label: 'Escalate',
-        text: 'Consider ruxolitinib 1.5% cream for ages two and older or systemic therapy when severe or refractory.'
+        label: 'Escalation & referral',
+        text: 'Refer when disease remains severe despite optimized topicals, growth falters, or systemic therapy/phototherapy is considered; urgent evaluation for suspected eczema herpeticum (monomorphic punched-out lesions).'
       }
     ],
     answerSummary:
-      'Layer barrier repair, anti-inflammatory therapy, and infection prevention; escalate quickly if quality of life suffers.',
+      'Optimize moisturization, targeted topical anti-inflammatories, and infection control; escalate quickly to specialist therapies when quality of life suffers or complications arise.',
     imageSearch: {
-      query: 'atopic dermatitis wet wrap therapy children',
-      label: 'Search Google Images for atopic dermatitis treatments'
+      query: 'atopic dermatitis wet wrap bleach bath child',
+      label: 'Search Google Images for atopic dermatitis management'
     },
     explanation: [
-      'Barrier restoration anchors therapy, while topical steroids tailored to body site control inflammation. Calcineurin inhibitors and new JAK creams provide steroid-sparing options, and early referral prevents prolonged sleep disruption or growth issues.'
+      'Weekend steroid maintenance or proactive calcineurin inhibitors reduce relapses. Document action plans covering flares, infection warning signs, and medication potency to avoid misuse.'
     ],
     sources: [
       {
-        label: 'American Academy of Pediatrics – Treatment of Atopic Dermatitis',
+        label: 'American Academy of Dermatology – Atopic Dermatitis Guidelines Update 2023',
+        url: 'https://www.jaad.org/article/S0190-9622(22)02730-0/fulltext?utm_source=chatgpt.com'
+      },
+      {
+        label: 'AAP – Eczema Management',
         url: 'https://www.aap.org/en/patient-care/atopic-dermatitis/treatment-of-atopic-dermatitis/?utm_source=chatgpt.com'
-      },
-      {
-        label: 'AAAAI 2023 Atopic Dermatitis Guideline',
-        url: 'https://www.aaaai.org/Aaaai/media/Media-Library-PDFs/Allergist%20Resources/Statements%20and%20Practice%20Parameters/JTF-Atopic-Dermatitis-Guideline-2023-07-31-2026.pdf?utm_source=chatgpt.com'
-      },
-      {
-        label: 'Managed Healthcare Executive – Opzelura label expansion',
-        url: 'https://www.managedhealthcareexecutive.com/view/fda-expands-approval-of-opzelura-cream-to-children-ages-2-to-11-with-atopic-dermatitis?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-diaper-dermatitis',
-    title: 'Diaper Dermatitis',
-    shortLabel: 'Diaper dermatitis',
-    prompt: {
-      lead: 'Presentation',
-      text: 'Beefy erythema across convex diaper surfaces with satellite pustules—what is it and how do you treat it?'
-    },
-    answerPoints: [
-      {
-        label: 'Likely diagnosis',
-        text: 'Irritant diaper dermatitis with Candida involvement when satellites are present.'
-      },
-      { label: 'Testing', text: 'KOH prep if the diagnosis is uncertain.' },
-      {
-        label: 'Treatment',
-        text: 'Thick barrier paste every change, open-air time, topical azole for Candida, and brief low-potency steroid for marked inflammation.'
-      }
-    ],
-    answerSummary:
-      'Moisture control plus antifungal or low-dose steroid therapy soothes diaper dermatitis while protecting thin skin.',
-    imageSearch: {
-      query: 'diaper dermatitis candida satellite lesions',
-      label: 'Search Google Images for diaper dermatitis'
-    },
-    explanation: [
-      'Barrier dysfunction drives irritant diaper dermatitis. Candida superinfection introduces satellite pustules and fold involvement, prompting topical azole therapy alongside aggressive barrier protection.'
-    ],
-    sources: [
-      {
-        label: 'AAP Pediatric Care – Diaper Rash',
-        url: 'https://publications.aap.org/pediatriccare/article/doi/10.1542/aap.ppcqr.396155/1621/Diaper-Rash?utm_source=chatgpt.com'
-      }
-    ]
-  },
-  {
-    id: 'condition-hand-foot-mouth',
-    title: 'Hand-Foot-Mouth Disease',
-    shortLabel: 'Hand-foot-mouth disease',
-    prompt: {
-      lead: 'Clue',
-      text: 'Low fever plus oral ulcers and palm or sole vesicles—what is the diagnosis and mainstay of care?'
-    },
-    answerPoints: [
-      { label: 'Diagnosis', text: 'Hand-foot-mouth disease, usually from coxsackievirus.' },
-      { label: 'Testing', text: 'Clinical; viral testing rarely needed.' },
-      {
-        label: 'Treatment',
-        text: 'Supportive care with hydration and pain control. Children can attend daycare when afebrile, well, and without uncontrolled drooling.'
-      }
-    ],
-    answerSummary:
-      'Hand-foot-mouth disease is a clinical diagnosis—focus on comfort and hydration while counseling on contagion.',
-    imageSearch: {
-      query: 'hand foot mouth disease child rash',
-      label: 'Search Google Images for HFMD'
-    },
-    explanation: [
-      'Hand-foot-mouth vesicles rupture into painful erosions, so analgesia and cold fluids improve intake. Families should watch for dehydration and recognize that viral shedding continues for weeks.'
-    ],
-    sources: [
-      {
-        label: 'CDC – About hand, foot, and mouth disease',
-        url: 'https://www.cdc.gov/hand-foot-mouth/about/index.html?utm_source=chatgpt.com'
-      }
-    ]
-  },
-  {
-    id: 'condition-impetigo',
+    id: 'impetigo',
     title: 'Impetigo',
     shortLabel: 'Impetigo',
     prompt: {
-      lead: 'Clue',
-      text: 'Honey-colored crusts on the face after eczema scratching—what is the diagnosis and first-line therapy?'
+      lead: 'Crusted lesions',
+      text: 'Child with rapidly spreading honey-colored crusts around the nose—identify the diagnosis and treatment plan.'
     },
     answerPoints: [
       {
-        label: 'Diagnosis',
-        text: 'Impetigo (nonbullous or bullous) from Staphylococcus aureus or Streptococcus pyogenes.'
+        label: 'History & exam',
+        text: 'Non-bullous impetigo presents with papules that evolve into pustules and honey-colored crusts, often after skin trauma or eczema; bullous disease shows flaccid bullae.'
       },
       {
         label: 'Testing',
-        text: 'Culture for outbreaks, treatment failure, or MRSA risk.'
+        text: 'Usually clinical; obtain bacterial culture when MRSA is suspected, during outbreaks, or after treatment failure.'
       },
       {
-        label: 'Treatment',
-        text: 'Topical mupirocin or retapamulin for limited lesions; oral cephalexin (or MRSA-active agent) for widespread disease.'
-      },
-      { label: 'Watch for', text: 'Rare post-streptococcal glomerulonephritis.' }
+        label: 'Management',
+        text: 'Limited lesions: topical mupirocin or retapamulin for 5 days. Extensive disease or MRSA risk: oral antibiotics (e.g., cephalexin, dicloxacillin, or clindamycin based on local resistance). Reinforce hygiene and exclude from daycare until 24 hours of therapy.'
+      }
     ],
     answerSummary:
-      'Crusted lesions need targeted anti-staphylococcal therapy, with cultures guiding community MRSA coverage.',
+      'Classic honey-colored crusts signal impetigo—use topical therapy for localized disease and oral antibiotics when lesions are numerous or MRSA is a concern.',
     imageSearch: {
-      query: 'pediatric impetigo honey crust',
+      query: 'pediatric impetigo honey colored crust',
       label: 'Search Google Images for impetigo'
     },
     explanation: [
-      'Topical therapy suffices for localized impetigo, while widespread disease requires oral antibiotics covering group A strep and MSSA. Document lesion count and household contacts to manage outbreaks.'
+      'Treat underlying eczema to prevent recurrence. Counsel on hand hygiene, not sharing towels, and trimming nails to limit spread.'
     ],
     sources: [
       {
-        label: 'CDC – Clinical guidance for impetigo',
+        label: 'CDC – Clinical Guidance for Impetigo',
         url: 'https://www.cdc.gov/group-a-strep/hcp/clinical-guidance/impetigo.html?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-infantile-hemangioma',
-    title: 'Infantile Hemangioma',
-    shortLabel: 'Infantile hemangioma',
+    id: 'tinea-corporis-capitis',
+    title: 'Tinea Corporis & Capitis',
+    shortLabel: 'Tinea infections',
     prompt: {
-      lead: 'Clue',
-      text: 'Rapidly growing red-purple plaque in an infant—what should you remember about timing, risk, and treatment?'
+      lead: 'Annular rash',
+      text: 'Ringlike scaly plaque on the arm or scaly alopecic patch on the scalp—what confirms tinea and how do you treat it?'
     },
     answerPoints: [
-      { label: 'Growth', text: 'Peaks by three to five months; most proliferation complete by five months.' },
       {
-        label: 'High-risk sites',
-        text: 'Periocular, airway, beard area, ulcerated, segmental, or multiple lesions.'
+        label: 'Clues',
+        text: 'Corporis: annular plaques with active scaly border; capitis: patchy alopecia, scale, black dots, or boggy kerion, often with animal or fomite exposure.'
       },
       {
-        label: 'Workup',
-        text: 'Clinical; imaging for deep or uncertain lesions or syndromic concern. Screen for PHACE or LUMBAR when indicated.'
+        label: 'Testing',
+        text: 'Perform KOH scraping from the active border; send fungal culture when diagnosis is uncertain. Wood’s lamp aids Microsporum detection.'
       },
       {
         label: 'Treatment',
-        text: 'Early risk stratification; oral propranolol first-line for threatening lesions; topical timolol for small superficial lesions; meticulous ulcer care.'
+        text: 'Corporis: topical allylamine or azole applied 1–2 weeks beyond clearance. Capitis: oral antifungal (griseofulvin or terbinafine based on species/age) plus antifungal shampoo 2–3 times weekly for patient and close contacts; add short oral steroid for severe kerion with specialist input.'
       }
     ],
     answerSummary:
-      'Refer high-risk hemangiomas early—propranolol within the first month prevents functional loss and disfigurement.',
+      'Confirm tinea with KOH microscopy and treat corporis topically but capitis with systemic antifungals and adjunctive shampoos.',
     imageSearch: {
-      query: 'infantile hemangioma infant face',
-      label: 'Search Google Images for infantile hemangioma'
+      query: 'tinea corporis annular rash child kerion capitis',
+      label: 'Search Google Images for tinea corporis and capitis'
     },
     explanation: [
-      'Because rapid growth occurs in the first months, prompt recognition and referral enable timely propranolol therapy. Segmental facial lesions warrant evaluation for PHACE syndrome, while lumbosacral lesions can signal LUMBAR association.'
+      'Avoid topical steroids alone, which mask tinea (tinea incognito). Educate families on not sharing hair accessories or hats during treatment.'
     ],
     sources: [
       {
-        label: 'AAP – Infantile hemangioma guideline',
-        url: 'https://publications.aap.org/pediatrics/article/143/1/e20183475/37268/Clinical-Practice-Guideline-for-the-Management-of?utm_source=chatgpt.com'
+        label: 'American Family Physician – Diagnosis and Management of Tinea Infections',
+        url: 'https://www.aafp.org/pubs/afp/issues/2014/1115/p702.html?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-molluscum',
-    title: 'Molluscum Contagiosum',
-    shortLabel: 'Molluscum contagiosum',
-    prompt: {
-      lead: 'Pearl',
-      text: 'Umbilicated pearly papules on flexural skin—what is the typical course and when do you treat?'
-    },
-    answerPoints: [
-      { label: 'Diagnosis', text: 'Molluscum contagiosum, common in atopic children.' },
-      { label: 'Course', text: 'Self-resolves over months to years.' },
-      {
-        label: 'Treatment',
-        text: 'Reassurance or procedures (curettage, cryotherapy, cantharidin). Use cantharidin (Ycanth) for ages two and older when lesions are numerous, spreading, symptomatic, or psychosocially distressing.'
-      }
-    ],
-    answerSummary:
-      'Most molluscum clears without intervention; treat when lesions bother the child or complicate eczema.',
-    imageSearch: {
-      query: 'molluscum contagiosum child lesions',
-      label: 'Search Google Images for molluscum'
-    },
-    explanation: [
-      'Lesions autoinoculate along lines of trauma, so eczema control is key. When therapy is requested, discuss realistic timelines and potential irritation from destructive modalities.'
-    ],
-    sources: [
-      {
-        label: 'Texas Children’s – Molluscum contagiosum referral guide',
-        url: 'https://www.texaschildrens.org/sites/default/files/uploads/molluscum%20contagiosum_0.pdf?utm_source=chatgpt.com'
-      },
-      {
-        label: 'FDA – Ycanth label',
-        url: 'https://www.accessdata.fda.gov/drugsatfda_docs/label/2023/212905s000lbl.pdf?utm_source=chatgpt.com'
-      }
-    ]
-  },
-  {
-    id: 'condition-psoriasis',
-    title: 'Psoriasis (Pediatric)',
-    shortLabel: 'Psoriasis',
-    prompt: {
-      lead: 'Pattern',
-      text: 'Well-demarcated erythematous plaques with silvery scale on extensor surfaces—what is the diagnosis and management overview?'
-    },
-    answerPoints: [
-      { label: 'Diagnosis', text: 'Plaque psoriasis; screen for psoriatic arthritis symptoms.' },
-      {
-        label: 'Treatment',
-        text: 'Topical corticosteroids (potency by site and age) plus vitamin D analogs; calcineurin inhibitors for face and genitals.'
-      },
-      {
-        label: 'Escalation',
-        text: 'Phototherapy or systemic and biologic therapy for moderate-severe or refractory disease in partnership with dermatology.'
-      }
-    ],
-    answerSummary:
-      'Psoriasis features sharply bordered plaques—combine topical steroids with adjuncts and escalate early for joint symptoms.',
-    imageSearch: {
-      query: 'pediatric psoriasis plaque',
-      label: 'Search Google Images for pediatric psoriasis'
-    },
-    explanation: [
-      'Pediatric psoriasis can impair quality of life and carries arthritis risk. Encourage moisturizers, manage triggers, and partner with dermatology for systemic therapy when body surface area or impact is high.'
-    ],
-    sources: [
-      {
-        label: 'JAAD – Pediatric psoriasis guideline',
-        url: 'https://www.jaad.org/article/S0190-9622%2819%2932655-6/fulltext?utm_source=chatgpt.com'
-      }
-    ]
-  },
-  {
-    id: 'condition-scabies',
+    id: 'scabies',
     title: 'Scabies',
     shortLabel: 'Scabies',
     prompt: {
-      lead: 'Clue',
-      text: 'Intense nocturnal itch with burrows in finger webs—how do you confirm and treat?'
+      lead: 'Nighttime itch',
+      text: 'Child with intense nocturnal pruritus and burrows between fingers—what is the diagnosis and treatment?'
     },
     answerPoints: [
       {
-        label: 'Diagnosis',
-        text: 'Scabies—clinical plus mineral oil scraping or dermoscopy when uncertain.'
+        label: 'History & exam',
+        text: 'Itch worse at night, family members affected. Burrows, papules, and vesicles on finger webs, wrists, axillae, waistline; infants may involve scalp, palms, and soles.'
       },
       {
-        label: 'Treatment',
-        text: 'Permethrin 5% cream neck-down (include scalp in infants) repeated in seven days; treat close contacts and decontaminate linens.'
+        label: 'Testing',
+        text: 'Diagnosis is clinical; confirm with dermoscopy, burrow ink test, or skin scraping microscopy when feasible.'
       },
       {
-        label: 'Escalate',
-        text: 'Oral ivermectin for outbreaks or refractory cases (check age and weight guidance).'
+        label: 'Management',
+        text: 'Permethrin 5% cream from neck down (include scalp for infants), under nails, left on 8–12 hours then rinsed; repeat in 7–10 days. Treat all close contacts simultaneously, launder bedding/clothing hot or seal for ≥72 hours, and address post-scabetic itch with emollients or low-potency steroids.'
       }
     ],
     answerSummary:
-      'Treat the patient and contacts with permethrin, repeat in a week, and manage the environment to prevent reinfestation.',
+      'Treat scabies with permethrin applied to all contacts, environmental decontamination, and symptomatic care for persistent itch.',
     imageSearch: {
-      query: 'scabies burrow pediatric',
-      label: 'Search Google Images for scabies'
+      query: 'pediatric scabies burrows finger webs treatment',
+      label: 'Search Google Images for scabies management'
     },
     explanation: [
-      'Scabies mites tunnel in thin skin, creating pruritic papules and burrows. Confirming mites can bolster adherence, but treatment should start promptly to relieve symptoms and curb spread.'
+      'Consider oral ivermectin for crusted scabies or failed topical therapy in children >15 kg per specialist guidance. Reinfection occurs if contacts are untreated.'
     ],
     sources: [
       {
-        label: 'CDC – Clinical care of scabies',
+        label: 'CDC – Clinical Care of Scabies',
         url: 'https://www.cdc.gov/scabies/hcp/clinical-care/index.html?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-seborrheic-dermatitis',
-    title: 'Seborrheic Dermatitis (Cradle Cap)',
-    shortLabel: 'Seborrheic dermatitis',
+    id: 'molluscum-contagiosum',
+    title: 'Molluscum Contagiosum',
+    shortLabel: 'Molluscum',
     prompt: {
-      lead: 'Presentation',
-      text: 'Greasy yellow scale on an otherwise content infant’s scalp—what is the diagnosis and how do you counsel parents?'
+      lead: 'Umbilicated papules',
+      text: 'Child with clusters of dome-shaped umbilicated papules—what counseling and treatment options do you offer?'
     },
     answerPoints: [
-      { label: 'Diagnosis', text: 'Infantile seborrheic dermatitis (cradle cap).' },
       {
-        label: 'Treatment',
-        text: 'Gentle daily shampoo, soften scale with mineral oil or petrolatum and brush off; consider ketoconazole 2% cream or shampoo if extensive or persistent.'
+        label: 'Key features',
+        text: 'Discrete pearly papules with central umbilication; often surrounded by eczematous halos, especially in atopic children; spread via skin-to-skin contact or fomites (pools, towels).'
       },
-      { label: 'Prognosis', text: 'Typically resolves by six to twelve months.' }
+      {
+        label: 'Testing',
+        text: 'Clinical diagnosis; no labs required.'
+      },
+      {
+        label: 'Management',
+        text: 'Reassure about self-resolution over months to 2 years. Consider treatment for symptomatic or spreading lesions: in-office cantharidin, curettage in older children, or topical retinoids/immunotherapy. Treat associated eczema with gentle skin care and mild steroids; advise against scratching or shaving.'
+      }
     ],
     answerSummary:
-      'Cradle cap is benign—focus on gentle keratolysis and reassure about spontaneous resolution.',
+      'Most molluscum clears spontaneously—treat only when symptomatic or psychosocially distressing while controlling surrounding eczema.',
     imageSearch: {
-      query: 'infant cradle cap seborrheic dermatitis',
-      label: 'Search Google Images for cradle cap'
+      query: 'molluscum contagiosum child umbilicated papules',
+      label: 'Search Google Images for molluscum contagiosum'
     },
     explanation: [
-      'Seborrheic dermatitis stems from Malassezia overgrowth in sebaceous areas. Emphasize gentle removal rather than aggressive scrubbing to avoid scalp irritation.'
+      'Cover lesions for contact sports to limit spread. Post-inflammatory hypopigmentation may linger after treatment.'
     ],
     sources: [
       {
-        label: 'HealthyChildren.org – What is cradle cap?',
-        url: 'https://www.healthychildren.org/English/ages-stages/baby/bathing-skin-care/Pages/Cradle-Cap.aspx?utm_source=chatgpt.com'
+        label: 'CDC – Molluscum Contagiosum',
+        url: 'https://www.cdc.gov/poxvirus/molluscum-contagiosum/clinicians/index.html?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-tinea',
-    title: 'Tinea Infections',
-    shortLabel: 'Tinea infections',
+    id: 'viral-warts',
+    title: 'Viral Warts (HPV)',
+    shortLabel: 'Viral warts',
     prompt: {
-      lead: 'Case',
-      text: 'Round scaly patches with alopecia and “black dots” in the scalp—what test and treatment are needed?'
+      lead: 'Stubborn papules',
+      text: 'Child with hyperkeratotic papules that interrupt skin lines—what management options exist?'
+    },
+    answerPoints: [
+      {
+        label: 'Features',
+        text: 'Verrucous papules with black punctate dots (thrombosed capillaries); plantar warts may be painful. Review habits like nail biting or shaving that spread lesions.'
+      },
+      {
+        label: 'Testing',
+        text: 'Clinical diagnosis; no laboratory confirmation needed.'
+      },
+      {
+        label: 'Treatment',
+        text: 'First-line salicylic acid with nightly application and occlusion plus weekly paring for 2–3 months. Office options include cryotherapy every 2–3 weeks, cantharidin, or immunotherapy (contact allergens). Counsel that spontaneous resolution is common.'
+      }
+    ],
+    answerSummary:
+      'Treat warts conservatively with salicylic acid and occlusion, reserving cryotherapy or immunotherapy for persistent lesions while noting many self-resolve.',
+    imageSearch: {
+      query: 'pediatric plantar wart salicylic acid treatment',
+      label: 'Search Google Images for pediatric warts'
+    },
+    explanation: [
+      'Combine salicylic acid with duct-tape occlusion to enhance efficacy. Address pain with cushioning pads for plantar lesions.'
+    ],
+    sources: [
+      {
+        label: 'American Academy of Dermatology – Warts in Children',
+        url: 'https://www.aad.org/public/diseases/a-z/warts-treatment?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'acne',
+    title: 'Acne (Preadolescent & Adolescent)',
+    shortLabel: 'Acne',
+    prompt: {
+      lead: 'Breakouts',
+      text: 'Teenager with comedones and inflammatory papules—how do you stage and treat acne?'
+    },
+    answerPoints: [
+      {
+        label: 'Assessment',
+        text: 'Determine severity (comedonal vs inflammatory vs nodulocystic), distribution (face, chest, back), psychosocial impact, and medications (steroids, lithium).'
+      },
+      {
+        label: 'Treatment',
+        text: 'Mild: topical retinoid nightly plus benzoyl peroxide (BP). Moderate: add topical antibiotic (clindamycin) always with BP or consider oral doxycycline/minocycline for limited course. Severe/scarring: refer for isotretinoin; consider hormonal therapy (combined oral contraceptives, spironolactone) in appropriate menstruating patients.'
+      },
+      {
+        label: 'Counseling',
+        text: 'Use gentle cleansers, non-comedogenic moisturizers, avoid picking, and discuss sun protection and pregnancy prevention for teratogenic medications.'
+      }
+    ],
+    answerSummary:
+      'Match acne therapy to severity—pair retinoids with benzoyl peroxide, limit antibiotic monotherapy, and refer early for scarring nodular disease.',
+    imageSearch: {
+      query: 'teen acne treatment regimen benzoyl peroxide retinoid',
+      label: 'Search Google Images for acne management'
+    },
+    explanation: [
+      'Maintenance retinoid use prevents new lesions. Oral antibiotics should be paired with topical retinoid/BP and limited to 3–4 months to curb resistance.'
+    ],
+    sources: [
+      {
+        label: 'American Academy of Dermatology – Acne Guidelines 2024',
+        url: 'https://www.jaad.org/article/S0190-9622(23)00389-3/fulltext?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'diaper-dermatitis',
+    title: 'Diaper Dermatitis (Irritant & Candida)',
+    shortLabel: 'Diaper dermatitis',
+    prompt: {
+      lead: 'Diaper rash',
+      text: 'Infant with erythema in the diaper area—how do you distinguish irritant vs Candida and manage each?'
+    },
+    answerPoints: [
+      {
+        label: 'Pattern recognition',
+        text: 'Irritant dermatitis: confluent erythema on convex surfaces sparing skin folds. Candida: beefy red plaques involving folds with satellite pustules, often after antibiotics or diarrhea.'
+      },
+      {
+        label: 'Management basics',
+        text: 'Frequent diaper changes, super-absorbent diapers, gentle cleansing, and thick barrier paste (zinc oxide or petrolatum) at each change; provide diaper-free time.'
+      },
+      {
+        label: 'Targeted therapy',
+        text: 'Add low-potency topical steroid briefly for severe irritant rash. Start topical antifungal (nystatin or azole) when Candida suspected; continue 2–3 days past resolution.'
+      }
+    ],
+    answerSummary:
+      'Differentiate irritant from Candida by fold involvement and satellite lesions, then pair barrier care with antifungals or mild steroids as indicated.',
+    imageSearch: {
+      query: 'diaper dermatitis candida satellite pustules treatment',
+      label: 'Search Google Images for diaper dermatitis'
+    },
+    explanation: [
+      'Avoid fragranced wipes and allow air exposure. Escalate for persistent rash, ulceration, or systemic illness to rule out immunodeficiency or histiocytosis.'
+    ],
+    sources: [
+      {
+        label: 'AAP – Diaper Rash Guidance',
+        url: 'https://publications.aap.org/pediatriccare/article/doi/10.1542/aap.ppcqr.396155/1621/Diaper-Rash?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'pityriasis-rosea',
+    title: 'Pityriasis Rosea',
+    shortLabel: 'Pityriasis rosea',
+    prompt: {
+      lead: 'Herald patch',
+      text: 'Adolescent with herald patch followed by oval salmon plaques on the trunk—what should you counsel?'
+    },
+    answerPoints: [
+      {
+        label: 'Features',
+        text: 'Often preceded by mild viral prodrome; herald patch precedes a “Christmas tree” distribution of oval plaques along skin tension lines, occasionally involving face in children.'
+      },
+      {
+        label: 'Testing',
+        text: 'Clinical diagnosis; order RPR or other serologies only if lesions are atypical or involve palms/soles to rule out syphilis or other mimics.'
+      },
+      {
+        label: 'Management',
+        text: 'Self-limited over 6–10 weeks. Manage itch with emollients, low- to mid-potency topical steroids, or oral antihistamines; consider narrowband UVB or short-course antivirals in severe, early, or extensive cases.'
+      }
+    ],
+    answerSummary:
+      'Pityriasis rosea is self-resolving—focus on reassurance and pruritus control while ruling out mimics when distribution is atypical.',
+    imageSearch: {
+      query: 'pityriasis rosea herald patch christmas tree rash child',
+      label: 'Search Google Images for pityriasis rosea'
+    },
+    explanation: [
+      'Educate about post-inflammatory hyperpigmentation, particularly in darker skin types, and advise return if systemic symptoms develop.'
+    ],
+    sources: [
+      {
+        label: 'DermNet – Pityriasis Rosea',
+        url: 'https://dermnetnz.org/topics/pityriasis-rosea?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'urticaria-acute',
+    title: 'Urticaria (Acute)',
+    shortLabel: 'Urticaria (acute)',
+    prompt: {
+      lead: 'Sudden hives',
+      text: 'Child develops transient wheals after viral illness—how do you manage acute urticaria safely?'
+    },
+    answerPoints: [
+      {
+        label: 'History & exam',
+        text: 'Onset within hours to days; lesions are transient (<24 hours) and migratory. Investigate infection, foods, medications, insect stings, and evaluate for angioedema or systemic symptoms (wheeze, hypotension, vomiting).'
+      },
+      {
+        label: 'Testing',
+        text: 'No routine labs in uncomplicated acute urticaria; testing is reserved for suspected anaphylaxis or systemic disease.'
+      },
+      {
+        label: 'Management',
+        text: 'Weight-based second-generation antihistamine daily until symptom-free for several days; add cool compresses. Provide epinephrine prescription and education when anaphylaxis risk factors or systemic symptoms are present.'
+      }
+    ],
+    answerSummary:
+      'Treat acute pediatric urticaria with non-sedating antihistamines and trigger avoidance, escalating to epinephrine only when systemic signs suggest anaphylaxis.',
+    imageSearch: {
+      query: 'pediatric acute urticaria wheals antihistamine',
+      label: 'Search Google Images for acute urticaria'
+    },
+    explanation: [
+      'Explain that viral infections are the most common cause in children and that hives may last up to 4–6 weeks before labeling as chronic.'
+    ],
+    sources: [
+      {
+        label: 'AAAAI – Acute Urticaria Guidance',
+        url: 'https://www.aaaai.org/conditions-treatments/library/allergy-library/urticaria-hives?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'hand-foot-mouth',
+    title: 'Hand-Foot-Mouth Disease',
+    shortLabel: 'HFMD',
+    prompt: {
+      lead: 'Vesicles and ulcers',
+      text: 'Toddler with low fever, oral ulcers, and vesicles on palms and soles—what is the management plan?'
     },
     answerPoints: [
       {
         label: 'Diagnosis',
-        text: 'Tinea capitis (or corporis or pedis when annular with an active border).'
+        text: 'Clinical features include oral ulcerations, vesicles or papules on hands, feet, buttocks, and occasional eczema coxsackium; consider daycare exposure during enterovirus season.'
       },
       {
         label: 'Testing',
-        text: 'KOH prep; fungal culture to identify the organism.'
+        text: 'Typically clinical; PCR reserved for severe, atypical, or outbreak situations.'
       },
       {
-        label: 'Treatment',
-        text: 'Oral griseofulvin or terbinafine for capitis with adjunct selenium sulfide or ketoconazole shampoo; topical allylamine or azole for corporis or pedis.'
+        label: 'Management',
+        text: 'Supportive care with hydration, age-appropriate analgesics, and soft foods. Exclude from daycare while febrile or drooling uncontrollably; monitor for dehydration or neurologic complications.'
       }
     ],
     answerSummary:
-      'Confirm dermatophytes with KOH and treat scalp disease systemically—topicals alone fail.',
+      'HFMD requires supportive care—prioritize hydration, analgesia, and infection control while reassuring families about the benign course.',
     imageSearch: {
-      query: 'tinea capitis black dot child',
-      label: 'Search Google Images for tinea infections'
+      query: 'hand foot mouth disease child mouth ulcers vesicles',
+      label: 'Search Google Images for hand foot mouth disease'
     },
     explanation: [
-      'Tinea capitis requires systemic therapy for follicular penetration. Choosing terbinafine versus griseofulvin depends on the suspected organism, while antifungal shampoos limit transmission.'
+      'Educate on frequent handwashing and disinfecting surfaces to limit spread; most children recover within 7–10 days.'
     ],
     sources: [
       {
-        label: 'AAFP – Common tinea infections in children',
-        url: 'https://www.aafp.org/pubs/afp/issues/2008/0515/p1415.html?utm_source=chatgpt.com'
+        label: 'CDC – Hand, Foot, and Mouth Disease',
+        url: 'https://www.cdc.gov/hand-foot-mouth/about/index.html?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'condition-urticaria',
-    title: 'Urticaria (Acute)',
-    shortLabel: 'Urticaria',
+    id: 'erythema-migrans',
+    title: 'Erythema Migrans (Lyme Disease)',
+    shortLabel: 'Erythema migrans',
     prompt: {
-      lead: 'Clue',
-      text: 'Transient pruritic wheals with or without angioedema—what evaluation and treatment steps are recommended?'
+      lead: 'Expanding rash',
+      text: 'Child in an endemic area has an expanding annular plaque days after a tick bite—how do you respond?'
     },
     answerPoints: [
-      { label: 'Evaluation', text: 'Usually none beyond history and exam; screen for anaphylaxis symptoms.' },
       {
-        label: 'Treatment',
-        text: 'Second-generation H1 antihistamines such as cetirizine, loratadine, or fexofenadine with up-titration for control.'
+        label: 'Recognition',
+        text: 'Expanding erythematous plaque ≥5 cm with or without central clearing, often accompanied by fatigue, headache, or arthralgia; may lack the classic bull’s-eye appearance.'
       },
       {
-        label: 'Escalation',
-        text: 'Reserve a short steroid burst for severe cases; administer IM epinephrine for anaphylaxis.'
+        label: 'Testing',
+        text: 'Early serology can be negative; do not delay treatment for classic erythema migrans. Consider testing if presentation is atypical or disseminated.'
+      },
+      {
+        label: 'Management',
+        text: 'Start empiric antibiotics per local guidelines (e.g., amoxicillin or doxycycline depending on age). Refer urgently for signs of neurologic, cardiac, or rheumatologic involvement.'
       }
     ],
     answerSummary:
-      'Treat acute urticaria with non-sedating antihistamines and be ready to manage anaphylaxis.',
+      'In endemic regions treat classic erythema migrans empirically with appropriate antibiotics and monitor for systemic Lyme manifestations.',
     imageSearch: {
-      query: 'acute urticaria wheals child',
-      label: 'Search Google Images for urticaria'
+      query: 'pediatric erythema migrans lyme expanding rash',
+      label: 'Search Google Images for erythema migrans'
     },
     explanation: [
-      'Acute hives are usually self-limited and do not need laboratory workup. Educate families on avoiding known triggers, dosing antihistamines correctly, and using epinephrine for systemic reactions.'
+      'Educate families on tick avoidance and prompt removal. Document baseline symptoms and follow-up to detect dissemination.'
     ],
     sources: [
       {
-        label: 'AAP – Urticaria, angioedema, and anaphylaxis review',
-        url: 'https://publications.aap.org/pediatricsinreview/article/41/6/283/35410/Urticaria-Angioedema-and-Anaphylaxis?utm_source=chatgpt.com'
+        label: 'CDC – Lyme Disease Clinical Care',
+        url: 'https://www.cdc.gov/lyme/hcp/clinical-care/index.html?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'infantile-hemangioma',
+    title: 'Infantile Hemangiomas',
+    shortLabel: 'Hemangiomas',
+    prompt: {
+      lead: 'Growing vascular lesion',
+      text: 'An infant develops a bright red plaque that grows rapidly—when do you reassure versus refer?'
+    },
+    answerPoints: [
+      {
+        label: 'Natural history',
+        text: 'Appear in first weeks of life, proliferate during first 3–5 months, then slowly involute over years; ulceration risk is highest on lips, diaper area, and flexures.'
+      },
+      {
+        label: 'Risk assessment',
+        text: 'High-risk features: segmental distribution, facial lesions near eye or airway, large (>5 cm), ulcerated, or multiple cutaneous lesions (>5) suggesting hepatic involvement.'
+      },
+      {
+        label: 'Management',
+        text: 'Observe uncomplicated small lesions. High-risk hemangiomas require early referral; oral propranolol (2–3 mg/kg/day divided) is first-line therapy when treatment indicated. Wound care for ulceration and consider imaging for lumbosacral or airway involvement.'
+      }
+    ],
+    answerSummary:
+      'Most infantile hemangiomas involute without therapy—identify high-risk lesions early for propranolol and specialist care to prevent functional compromise.',
+    imageSearch: {
+      query: 'infantile hemangioma propranolol treatment infant',
+      label: 'Search Google Images for infantile hemangiomas'
+    },
+    explanation: [
+      'Early referral (by 1 month of age) improves outcomes for high-risk lesions. Monitor for propranolol side effects (bradycardia, hypoglycemia) and educate parents on dosing with feeds.'
+    ],
+    sources: [
+      {
+        label: 'AAP Clinical Practice Guideline for Infantile Hemangiomas (2019)',
+        url: 'https://publications.aap.org/pediatrics/article/143/1/e20183475/37124/Clinical-Practice-Guideline-for-the-Management-of?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'vitiligo',
+    title: 'Vitiligo (Childhood)',
+    shortLabel: 'Vitiligo',
+    prompt: {
+      lead: 'Depigmented patches',
+      text: 'School-age child with well-demarcated depigmented macules—what evaluation and therapy do you consider?'
+    },
+    answerPoints: [
+      {
+        label: 'Assessment',
+        text: 'Document distribution (segmental vs non-segmental), rate of spread, Koebner phenomenon, and psychosocial impact; inquire about family history of autoimmunity.'
+      },
+      {
+        label: 'Workup',
+        text: 'Diagnosis is clinical aided by Wood’s lamp accentuation. Screen for thyroid disease or other autoimmune conditions when symptoms or family history suggest risk.'
+      },
+      {
+        label: 'Management',
+        text: 'Sun protection, topical corticosteroids or calcineurin inhibitors for limited areas, and narrowband UVB phototherapy for more extensive disease. Offer psychological support and consider camouflage cosmetics.'
+      }
+    ],
+    answerSummary:
+      'Vitiligo care centers on restoring pigment with topical or light therapy while screening for associated autoimmunity and supporting mental health.',
+    imageSearch: {
+      query: 'pediatric vitiligo wood lamp treatment options',
+      label: 'Search Google Images for pediatric vitiligo'
+    },
+    explanation: [
+      'Early treatment improves repigmentation potential. Discuss sun protection to prevent burns and contrast with unaffected skin.'
+    ],
+    sources: [
+      {
+        label: 'American Academy of Dermatology – Vitiligo Treatment',
+        url: 'https://www.aad.org/public/diseases/a-z/vitiligo-treatment?utm_source=chatgpt.com'
       }
     ]
   }
@@ -483,6 +585,6 @@ const cards = [
 
 export default {
   id: 'conditions',
-  label: 'Condition playbooks',
+  label: 'Condition Playbooks',
   cards
 };

--- a/projects/MediCards/PediatricDermatology/data/lesion-vocabulary.js
+++ b/projects/MediCards/PediatricDermatology/data/lesion-vocabulary.js
@@ -1,347 +1,382 @@
 const cards = [
   {
-    id: 'lesion-erythema',
-    title: 'Lesion Type: Erythema',
-    shortLabel: 'Erythema',
+    id: 'allergy-rhinitis',
+    title: 'Allergic Rhinitis (± Conjunctivitis)',
+    shortLabel: 'Allergic rhinitis',
     prompt: {
-      lead: 'Spot it',
-      text: 'When you see a diffuse red patch on inflamed skin, what are you looking at and why does it matter?'
+      lead: 'Clinic scenario',
+      text: 'Child with seasonal sneezing, itching, and congestion—how do you confirm allergic rhinitis and control symptoms?'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Blanchable redness from dilated superficial vessels signaling inflammation or irritation.'
+        label: 'History',
+        text: 'Paroxysmal sneezing, nasal itching, clear rhinorrhea, and congestion with seasonal or perennial triggers; ask about sleep impact and associated atopy or conjunctival itching.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Track temperature, tenderness, and borders to distinguish cellulitis from eczema flare.'
+        label: 'Exam',
+        text: 'Allergic shiners, Dennie–Morgan lines, transverse nasal crease, pale or boggy turbinates, and watery, itchy eyes without purulence.'
+      },
+      {
+        label: 'Testing',
+        text: 'Diagnosis is clinical; order targeted skin-prick testing (SPT) or serum IgE only if the result will change management (e.g., candidacy for immunotherapy).'
+      },
+      {
+        label: 'Management',
+        text: 'Allergen avoidance and saline irrigation → daily intranasal corticosteroid; add second-generation oral or intranasal antihistamine for breakthrough symptoms. Consider short oral steroids for severe obstruction and refer for allergen immunotherapy when control remains poor.'
       }
     ],
     answerSummary:
-      'Erythema reflects superficial vasodilation from inflammation, so borders, warmth, and tenderness guide your differential.',
+      'Seasonal itch, sneeze, and congestion point to allergic rhinitis—treat with avoidance, saline, and daily intranasal steroids, layering on antihistamines or immunotherapy when needed.',
     imageSearch: {
-      query: 'pediatric erythema skin lesion',
-      label: 'Search Google Images for erythema examples'
+      query: 'pediatric allergic rhinitis nasal crease turbinates',
+      label: 'Search Google Images for allergic rhinitis findings'
     },
     explanation: [
-      'Erythema is a primary lesion that reflects inflammatory vasodilation. In pediatrics it often accompanies eczema flares, drug eruptions, or cellulitis. Documenting borders and associated edema helps determine whether infection or dermatitis is more likely.'
+      'Intranasal corticosteroids are the most effective monotherapy for allergic rhinitis, reducing mucosal inflammation and congestion. Assess trigger burden, reinforce adherence to spray technique, and monitor comorbid asthma or eczema for coordinated care.'
     ],
     sources: [
       {
-        label: 'DermNet – Primary skin lesions',
-        url: 'https://dermnetnz.org/topics/primary-skin-lesions?utm_source=chatgpt.com'
+        label: 'AAAAI/ACAAI Rhinitis Practice Parameter (2020)',
+        url: 'https://www.jacionline.org/article/S0091-6749(20)31364-8/fulltext?utm_source=chatgpt.com'
+      },
+      {
+        label: 'ARIA Care Pathways',
+        url: 'https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10046619/?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-papule',
-    title: 'Lesion Type: Papule',
-    shortLabel: 'Papule',
+    id: 'allergy-food-ige',
+    title: 'IgE-Mediated Food Allergy',
+    shortLabel: 'Food allergy (IgE)',
     prompt: {
-      lead: 'Define it',
-      text: 'What is a papule and how does it guide your pediatric dermatology workup?'
+      lead: 'Rapid reaction',
+      text: 'Minutes after peanut ingestion a child develops hives and vomiting—outline the diagnostic approach and long-term plan.'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Solid, raised lesion under 1 cm; color ranges from skin-toned to erythematous.'
+        label: 'History',
+        text: 'Immediate (minutes to ≤2 hours) reproducible symptoms—urticaria, angioedema, wheeze, emesis, hypotension—after exposure to a specific food; review serving size, co-factors, and prior tolerance.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Assess umbilication, scale, and distribution to separate inflammatory papules from infectious causes.'
+        label: 'Exam',
+        text: 'Normal between reactions; during an acute episode look for cutaneous, respiratory, gastrointestinal, or cardiovascular signs of anaphylaxis.'
+      },
+      {
+        label: 'Testing',
+        text: 'Order targeted SPT or serum specific IgE guided by history; component testing (e.g., Ara h 2 for peanut) clarifies risk. Oral food challenge remains the gold standard when history and testing conflict.'
+      },
+      {
+        label: 'Management',
+        text: 'Institute strict avoidance, provide an emergency action plan, and prescribe appropriate-dose epinephrine autoinjectors (0.1/0.15/0.3 mg by weight). Consider oral immunotherapy with an allergy specialist and re-evaluate regularly for tolerance (e.g., baked milk/egg ladders). Ensure nutrition support.'
       }
     ],
     answerSummary:
-      'Papules are small solid bumps—surface changes such as umbilication or scale refine the differential.',
+      'Confirm IgE food allergy with history-driven testing, equip families with epinephrine and avoidance strategies, and revisit tolerance under specialist supervision.',
     imageSearch: {
-      query: 'pediatric papule skin lesion example',
-      label: 'Search Google Images for papules'
+      query: 'child food allergy hives emergency action plan',
+      label: 'Search Google Images for pediatric food allergy management'
     },
     explanation: [
-      'Papules represent dermal cellular infiltration or edema. In children, papular eruptions can signal eczema, viral exanthems, or arthropod reactions. Combine palpation with surface findings to narrow possibilities.'
+      'Sensitization without clinical reactivity is common, so anchor testing to a compelling history. Education on label reading, cross-contact prevention, and when to use epinephrine reduces morbidity while families await potential tolerance.'
     ],
     sources: [
       {
-        label: 'DermNet – Primary skin lesions',
-        url: 'https://dermnetnz.org/topics/primary-skin-lesions?utm_source=chatgpt.com'
+        label: 'NIAID Guidelines for Food Allergy',
+        url: 'https://www.niaid.nih.gov/diseases-conditions/guidelines-clinicians-and-patients-food-allergy?utm_source=chatgpt.com'
+      },
+      {
+        label: 'AAAAI Food Allergy Practice Parameter',
+        url: 'https://www.aaaai.org/practice-resources/statements-and-practice-parameters/food-allergy?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-vesicle',
-    title: 'Lesion Type: Vesicle',
-    shortLabel: 'Vesicle',
+    id: 'anaphylaxis-acute',
+    title: 'Anaphylaxis: Emergency Management',
+    shortLabel: 'Anaphylaxis',
     prompt: {
-      lead: 'Fluid clue',
-      text: 'Which lesion is a tiny fluid-filled blister and where do you expect to see it in pediatrics?'
+      lead: 'Emergency',
+      text: 'A child with peanut exposure develops hives, wheeze, and hypotension—detail the acute management steps.'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Small (under 1 cm) clear fluid-filled blister.'
+        label: 'Recognition',
+        text: 'Rapid-onset illness involving skin or mucosa plus respiratory compromise, hypotension, or severe gastrointestinal symptoms; anticipate biphasic reactions.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Common in acute eczema, varicella, and hand-foot-mouth disease—inspect for surrounding erythema or oral lesions.'
+        label: 'Immediate action',
+        text: 'Administer intramuscular epinephrine 0.01 mg/kg (1 mg/mL) to the anterolateral thigh, max 0.3 mg for children; repeat every 5–15 minutes as needed.'
+      },
+      {
+        label: 'Supportive care',
+        text: 'Position supine with legs elevated, give high-flow oxygen, establish IV access for isotonic fluids, and add adjunctive therapies only after epinephrine (SABA for bronchospasm, H1/H2 antihistamines, corticosteroids).'
+      },
+      {
+        label: 'Observation & discharge',
+        text: 'Monitor at least 4–6 hours (longer if severe or high risk), then discharge with two epinephrine autoinjectors, a written action plan, and allergy referral.'
       }
     ],
     answerSummary:
-      'Vesicles signal acute inflammation or viral infection, so distribution and mucosal findings steer management.',
+      'Treat anaphylaxis with prompt IM epinephrine, supportive positioning and fluids, then observe before discharge with action plans and autoinjectors.',
     imageSearch: {
-      query: 'pediatric vesicle blister skin',
-      label: 'Search Google Images for vesicles'
+      query: 'anaphylaxis emergency pediatric epinephrine thigh injection',
+      label: 'Search Google Images for pediatric anaphylaxis treatment'
     },
     explanation: [
-      'Vesicles form when fluid collects between epidermal layers. Their presence shifts suspicion toward acute eczema flares, viral exanthems, or bullous impetigo. Always assess for pain, honey crust, or systemic symptoms to rule out infection.'
+      'Delays in epinephrine drive morbidity. Education on thigh injection technique, supine positioning, and recognizing biphasic reactions empowers families and first responders.'
     ],
     sources: [
       {
-        label: 'DermNet – Vesicles',
-        url: 'https://dermnetnz.org/topics/blistering-diseases?utm_source=chatgpt.com'
+        label: 'World Allergy Organization Anaphylaxis Guidance 2020',
+        url: 'https://www.worldallergy.org/resources/anaphylaxis?utm_source=chatgpt.com'
+      },
+      {
+        label: 'AAAAI – Anaphylaxis Emergency Department Guidelines',
+        url: 'https://www.aaaai.org/tools-for-the-public/conditions-library/allergies/anaphylaxis?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-plaque',
-    title: 'Lesion Type: Plaque',
-    shortLabel: 'Plaque',
+    id: 'urticaria-angioedema',
+    title: 'Urticaria & Angioedema (Non-Anaphylactic)',
+    shortLabel: 'Urticaria (chronic)',
     prompt: {
-      lead: 'Shape check',
-      text: 'What defines a plaque and which pediatric rashes form them?'
+      lead: 'Clinic puzzle',
+      text: 'Child with itchy wheals recurring for weeks—how do you evaluate and manage non-anaphylactic urticaria?'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Raised, flat-topped lesion over 1 cm created by coalescing papules.'
+        label: 'History & triggers',
+        text: 'Pruritic wheals lasting <24 hours per spot and migrating, often post-infectious; chronic if >6 weeks. Screen for physical triggers, medications, or autoimmune disease; ensure no systemic compromise.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Look for plaques in psoriasis, nummular eczema, or tinea corporis with an active border.'
+        label: 'Exam',
+        text: 'Transient wheals or angioedema without respiratory distress or hypotension. Document absence of mucosal involvement suggestive of severe cutaneous adverse reactions.'
+      },
+      {
+        label: 'Testing',
+        text: 'Routine labs are unnecessary; pursue targeted workup (CBC, ESR/CRP, TSH) only if history suggests systemic disease or chronicity with red flags.'
+      },
+      {
+        label: 'Management',
+        text: 'Daily second-generation antihistamine at standard dose, uptitrating to fourfold dosing if needed. Short oral corticosteroid burst for severe flares. Avoid triggers and reserve epinephrine autoinjectors for patients with anaphylaxis risk.'
       }
     ],
     answerSummary:
-      'Plaques reflect confluent papules—texture, border, and scale separate eczema from psoriasis or tinea.',
+      'Chronic urticaria hinges on high-dose second-generation antihistamines and minimal lab work unless the story points elsewhere.',
     imageSearch: {
-      query: 'pediatric plaque skin lesion',
-      label: 'Search Google Images for skin plaques'
+      query: 'pediatric chronic urticaria wheals antihistamine',
+      label: 'Search Google Images for pediatric urticaria'
     },
     explanation: [
-      'Plaques often signal chronic inflammatory dermatoses. Sharply demarcated borders point to psoriasis, while annular plaques with trailing scale suggest tinea. Chronic scratching can convert papules into lichenified plaques.'
+      'Most pediatric chronic urticaria is idiopathic or post-viral. Educate families that lesions are fleeting and seldom dangerous, and escalate to omalizumab or cyclosporine only in refractory specialist-managed cases.'
     ],
     sources: [
       {
-        label: 'DermNet – Primary skin lesions',
-        url: 'https://dermnetnz.org/topics/primary-skin-lesions?utm_source=chatgpt.com'
+        label: 'EAACI Biologicals Guideline for Urticaria 2021',
+        url: 'https://onlinelibrary.wiley.com/doi/10.1111/all.14859?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-lichenification',
-    title: 'Lesion Type: Lichenification',
-    shortLabel: 'Lichenification',
+    id: 'allergic-asthma',
+    title: 'Asthma – Allergic Phenotype',
+    shortLabel: 'Asthma (allergic)',
     prompt: {
-      lead: 'Chronic clue',
-      text: 'What is lichenification and what does it reveal about disease timing?'
+      lead: 'Wheezy child',
+      text: 'Recurrent cough and wheeze triggered by allergens—how do you confirm allergic asthma and step therapy?'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Thickened skin with exaggerated lines from chronic rubbing or scratching.'
+        label: 'History',
+        text: 'Recurrent wheeze, cough, dyspnea, and nocturnal symptoms linked to viral infections, allergen exposure, exercise, or smoke; assess atopy and medication use.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Signals long-standing atopic dermatitis or lichen simplex—ask about itch control and sleep disruption.'
+        label: 'Exam & testing',
+        text: 'Often normal between flares; wheeze during exacerbation. Use spirometry with bronchodilator response ≥5–6 years and FeNO where available to characterize type 2 inflammation; allergy testing if results guide avoidance or biologics.'
+      },
+      {
+        label: 'Management',
+        text: 'Reliever: SABA or low-dose ICS–formoterol per age. Controller: start daily inhaled corticosteroid, stepping up to ICS–LABA or MART if poor control. Treat comorbid rhinitis, reinforce trigger reduction, spacer technique, asthma action plan, and yearly influenza vaccination.'
       }
     ],
     answerSummary:
-      'Lichenification equals chronic itch; address triggers and potent topical anti-inflammatories.',
+      'Document variable airflow limitation with spirometry, control allergens, and escalate from daily ICS to combination therapy while reinforcing inhaler technique.',
     imageSearch: {
-      query: 'lichenification chronic eczema child',
-      label: 'Search Google Images for lichenification'
+      query: 'pediatric asthma inhaler spacer education',
+      label: 'Search Google Images for pediatric asthma management'
     },
     explanation: [
-      'Chronic inflammation drives pruritus, thickening the epidermis and accentuating skin markings. Recognizing lichenification prompts escalation to medium-potency steroids, wet wraps, or systemic therapy if quality of life is impaired.'
+      'Allergic asthma shares pathways with rhinitis, so combined management improves outcomes. Frequent reliever use or exacerbations signal the need to step up therapy or assess adherence.'
     ],
     sources: [
       {
-        label: 'DermNet – Lichenification',
-        url: 'https://dermnetnz.org/topics/lichen-simplex?utm_source=chatgpt.com'
+        label: 'GINA 2023 Pocket Guide',
+        url: 'https://ginasthma.org/wp-content/uploads/2023/07/GINA-2023-Pocket-Guide-WMS.pdf?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-excoriation',
-    title: 'Lesion Type: Excoriation',
-    shortLabel: 'Excoriation',
+    id: 'allergic-conjunctivitis',
+    title: 'Allergic Conjunctivitis',
+    shortLabel: 'Allergic conjunctivitis',
     prompt: {
-      lead: 'Scratch marks',
-      text: 'How do you describe excoriations and what complications raise concern?'
+      lead: 'Eye itch',
+      text: 'Bilateral itchy, watery eyes without purulence—outline diagnosis and treatment.'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Linear erosions from scratching that may crust or bleed.'
+        label: 'History & exam',
+        text: 'Intense itching, tearing, mild lid edema, and conjunctival injection, often with concomitant rhinitis; vision remains normal and no purulent discharge.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Excoriations invite secondary infection—screen for impetigo, scabies, or poorly controlled itch.'
+        label: 'Testing',
+        text: 'Clinical diagnosis; allergy testing only when results will influence immunotherapy decisions.'
+      },
+      {
+        label: 'Management',
+        text: 'Allergen avoidance, cool compresses, lubricating drops, and topical antihistamine/mast-cell stabilizer drops. Reserve short topical ophthalmic steroids to an eye specialist for severe flares.'
       }
     ],
     answerSummary:
-      'Excoriations are self-inflicted breaks that raise infection risk; treat the itch and monitor for impetigo.',
+      'Allergic conjunctivitis presents with bilateral itchy, watery eyes—treat with avoidance, lubricants, and topical antihistamine/mast-cell stabilizers.',
     imageSearch: {
-      query: 'excoriation scratching child skin',
-      label: 'Search Google Images for excoriations'
+      query: 'allergic conjunctivitis child itchy watery eyes',
+      label: 'Search Google Images for allergic conjunctivitis'
     },
     explanation: [
-      'Scratching disrupts the epidermal barrier, letting bacteria colonize and causing stinging. Address pruritus with topical anti-inflammatories and consider bleach baths when excoriations are widespread.'
+      'Avoid chronic vasoconstrictor drops. Address accompanying rhinitis and consider oral antihistamines for systemic relief.'
     ],
     sources: [
       {
-        label: 'DermNet – Excoriations',
-        url: 'https://dermnetnz.org/topics/excoriation-skin-picking-disorder?utm_source=chatgpt.com'
+        label: 'American Academy of Ophthalmology – Allergic Conjunctivitis PPP',
+        url: 'https://www.aao.org/preferred-practice-pattern/allergic-conjunctivitis-ppp-2018?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-crusting',
-    title: 'Lesion Type: Crusting',
-    shortLabel: 'Crusting',
+    id: 'allergic-contact-dermatitis',
+    title: 'Allergic Contact Dermatitis',
+    shortLabel: 'Contact dermatitis',
     prompt: {
-      lead: 'Surface change',
-      text: 'What does crusting indicate and how is it formed?'
+      lead: 'Delayed rash',
+      text: 'Child develops a pruritic, well-demarcated rash 48 hours after wearing new earrings—what is the workup and management?'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Dried serum, blood, or pus on the skin surface.'
+        label: 'Clues',
+        text: 'Delayed (48–72 hour) pruritic erythema, papules, or vesicles at exposure sites (nickel, fragrances, neomycin); chronic cases show lichenification.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Honey-colored crusting suggests impetigo; thin serous crust follows vesicle rupture in eczema.'
+        label: 'Testing',
+        text: 'Consider patch testing when the allergen is unclear or dermatitis persists despite avoidance.'
+      },
+      {
+        label: 'Treatment',
+        text: 'Strict avoidance, mid-potency topical steroids for limited areas, emollients to restore barrier, and topical calcineurin inhibitors for sensitive sites (face, flexures).'
       }
     ],
     answerSummary:
-      'Crusts are dried exudate—color and distribution point to infection versus resolving dermatitis.',
+      'Diagnose delayed contact dermatitis by exposure pattern, confirm with patch testing when needed, and manage with avoidance plus topical anti-inflammatories.',
     imageSearch: {
-      query: 'honey crust impetigo child',
-      label: 'Search Google Images for skin crusting'
+      query: 'pediatric allergic contact dermatitis nickel rash',
+      label: 'Search Google Images for allergic contact dermatitis'
     },
     explanation: [
-      'Crusting forms when exudate dries over inflamed skin. Golden crusts prompt impetigo coverage, whereas serous crust in eczema signals acute weeping that still needs anti-inflammatory therapy.'
+      'Education on hidden allergens (clothing fasteners, topical antibiotics) prevents recurrences. Widespread dermatitis may require a short oral steroid taper under supervision.'
     ],
     sources: [
       {
-        label: 'DermNet – Impetigo overview',
-        url: 'https://dermnetnz.org/topics/impetigo?utm_source=chatgpt.com'
+        label: 'American Contact Dermatitis Society – Pediatric Contact Dermatitis',
+        url: 'https://www.contactderm.org/resources/pediatric?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-scaling',
-    title: 'Lesion Type: Scaling',
-    shortLabel: 'Scaling',
+    id: 'insect-sting-allergy',
+    title: 'Insect Sting Allergy (Hymenoptera)',
+    shortLabel: 'Sting allergy',
     prompt: {
-      lead: 'Texture tell',
-      text: 'What is scaling and why does it help separate eczema from fungal disease?'
+      lead: 'Sting reaction',
+      text: 'Child with large local swelling after a bee sting versus systemic hives—how do you differentiate and treat?'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Flakes of stratum corneum shed from the surface.'
+        label: 'History',
+        text: 'Large local reactions cause swelling >10 cm that peaks at 24–48 hours; systemic reactions manifest as urticaria, respiratory compromise, or hypotension within minutes.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Diffuse fine scale fits eczema or seborrhea; leading-edge scale favors tinea corporis.'
+        label: 'Testing',
+        text: 'Order venom SPT or serum IgE only after systemic reactions or to guide immunotherapy; not indicated for isolated large local reactions.'
+      },
+      {
+        label: 'Management',
+        text: 'Local: cold compresses, oral antihistamines, short oral corticosteroid if severe. Systemic: prescribe epinephrine autoinjector, provide avoidance education, and refer for venom immunotherapy (>90% efficacy in preventing future anaphylaxis).'
       }
     ],
-    answerSummary: 'Scale character directs your differential—diffuse versus annular edge matters.',
+    answerSummary:
+      'Differentiate benign large local swellings from systemic anaphylaxis—reserve venom testing and immunotherapy for systemic reactions while supplying epinephrine.',
     imageSearch: {
-      query: 'pediatric skin scaling example',
-      label: 'Search Google Images for scaling lesions'
+      query: 'hymenoptera sting allergy child swelling management',
+      label: 'Search Google Images for insect sting allergy management'
     },
     explanation: [
-      'Scaling reflects abnormal keratinization or inflammation. Annular scaling with central clearing suggests tinea, while greasy scalp scale in infants suggests seborrheic dermatitis.'
+      'Large local reactions seldom progress to anaphylaxis, so reassure families while reviewing signs of systemic involvement and the importance of prompt epinephrine use when indicated.'
     ],
     sources: [
       {
-        label: 'DermNet – Scaling skin conditions',
-        url: 'https://dermnetnz.org/topics/scaly-skin?utm_source=chatgpt.com'
+        label: 'AAAAI Practice Parameter: Stinging Insect Hypersensitivity (2017)',
+        url: 'https://www.aaaai.org/Aaaai/media/MediaLibrary/PDF%20Documents/Practice%20and%20Parameters/Stinging-Insect-Allergy-2016.pdf?utm_source=chatgpt.com'
       }
     ]
   },
   {
-    id: 'lesion-erosion',
-    title: 'Lesion Type: Erosion',
-    shortLabel: 'Erosion',
+    id: 'drug-allergy-immediate',
+    title: 'Drug Allergy – Immediate Reactions',
+    shortLabel: 'Drug allergy (immediate)',
     prompt: {
-      lead: 'Surface loss',
-      text: 'How do you recognize an erosion and what usually precedes it?'
+      lead: 'Medication reaction',
+      text: 'A child labeled “penicillin allergic” developed hives within an hour of amoxicillin—what is the evidence-based approach?'
     },
     answerPoints: [
       {
-        label: 'Definition',
-        text: 'Shallow loss of epidermis that typically heals without scarring.'
+        label: 'History',
+        text: 'Clarify timing (minutes to <6 hours), symptoms (urticaria, angioedema, respiratory compromise), treatment received, and tolerance to related antibiotics; note that most reported penicillin allergies are not IgE mediated.'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Often follows vesicle or bulla rupture—watch for secondary infection in moist areas.'
+        label: 'Risk stratification',
+        text: 'Low-risk histories (isolated delayed rash, vague symptoms) are candidates for direct oral amoxicillin challenge; higher-risk presentations need penicillin skin testing followed by graded challenge.'
+      },
+      {
+        label: 'Management',
+        text: 'Avoid the culprit drug until evaluation. Document outcomes clearly to remove inaccurate allergy labels and expand antibiotic options.'
       }
     ],
     answerSummary:
-      'Erosions expose superficial dermis after blister rupture, so protect the barrier and monitor for infection.',
+      'Use history-based risk assessment, targeted testing, and supervised challenges to delabel inaccurate penicillin allergies and preserve first-line antibiotics.',
     imageSearch: {
-      query: 'skin erosion after blister pediatric',
-      label: 'Search Google Images for skin erosions'
+      query: 'pediatric penicillin allergy evaluation oral challenge',
+      label: 'Search Google Images for penicillin allergy testing'
     },
     explanation: [
-      'Erosions result from partial epidermal loss and are common in eczema flares, impetigo, and hand-foot-mouth disease. Keeping the area clean and moist accelerates re-epithelialization.'
+      'True IgE-mediated penicillin allergy wanes over time; delabeling reduces broad-spectrum antibiotic use, resistance, and costs.'
     ],
     sources: [
       {
-        label: 'DermNet – Erosions and ulcers',
-        url: 'https://dermnetnz.org/topics/erosions-and-ulcers?utm_source=chatgpt.com'
-      }
-    ]
-  },
-  {
-    id: 'lesion-fissure',
-    title: 'Lesion Type: Fissure',
-    shortLabel: 'Fissure',
-    prompt: {
-      lead: 'Painful clue',
-      text: 'What is a fissure and how does it influence management?'
-    },
-    answerPoints: [
-      {
-        label: 'Definition',
-        text: 'Linear crack in thickened skin that can extend into the dermis.'
+        label: 'AAAAI Penicillin Allergy Position Statement 2023',
+        url: 'https://www.aaaai.org/Aaaai/media/Media-Library-PDFs/Allergist%20Resources/Statements%20and%20Practice%20Parameters/Penicillin-Allergy-Position-Statement.pdf?utm_source=chatgpt.com'
       },
       {
-        label: 'Clinical pearl',
-        text: 'Common in chronic lichenified eczema—aggressive moisturization and potent topical steroids reduce recurrence.'
-      }
-    ],
-    answerSummary:
-      'Fissures indicate chronic inflammation with barrier breakdown—restore moisture and control inflammation to heal them.',
-    imageSearch: {
-      query: 'skin fissure eczema child',
-      label: 'Search Google Images for skin fissures'
-    },
-    explanation: [
-      'Fissures form when thickened, dry skin splits under tension. Pain limits adherence to topical regimens, so incorporate occlusive therapy, wet wraps, and systemic options when needed.'
-    ],
-    sources: [
-      {
-        label: 'DermNet – Fissures',
-        url: 'https://dermnetnz.org/topics/fissures?utm_source=chatgpt.com'
+        label: 'CDC – IS IT REALLY A PENICILLIN ALLERGY?',
+        url: 'https://www.cdc.gov/antibiotic-use/community/pdfs/penicillin-factsheet.pdf?utm_source=chatgpt.com'
       }
     ]
   }
 ];
 
 export default {
-  id: 'lesion-vocabulary',
-  label: 'Lesion vocabulary',
+  id: 'allergy-airway',
+  label: 'Allergy & Airway Essentials',
   cards
 };

--- a/projects/MediCards/PediatricDermatology/data/patterns.js
+++ b/projects/MediCards/PediatricDermatology/data/patterns.js
@@ -1,34 +1,33 @@
 const cards = [
   {
-    id: 'pattern-eczema-distribution',
-    title: 'Pattern Finder: Eczema Distribution',
-    shortLabel: 'Eczema distribution',
+    id: 'quick-differentials',
+    title: 'Quick Differentials by Clue',
+    shortLabel: 'Differential clues',
     prompt: {
-      lead: 'Pattern recognition',
-      text: 'Which distribution clues steer you toward atopic dermatitis?'
+      lead: 'Pattern pearls',
+      text: 'Match rapid visual clues to their most likely pediatric diagnosis.'
     },
     answerPoints: [
-      { text: 'Infants: cheeks and extensor surfaces dominate.' },
-      {
-        text: 'Children and adolescents: flexural surfaces such as antecubital and popliteal fossae, neck, and wrists.'
-      },
-      {
-        text: 'Expect ill-defined, symmetric patches that evolve from erythema and vesicles to crusting and lichenification.'
-      }
+      { label: 'Honey-colored crusts', text: 'Think impetigo—look for superficial erosions with golden crusts near nose or mouth.' },
+      { label: 'Annular scaly border', text: 'Tinea corporis until proven otherwise; confirm with KOH scraping from the active edge.' },
+      { label: 'Nocturnal itch in finger webs', text: 'Classic for scabies; inspect for burrows and treat household contacts.' },
+      { label: 'Umbilicated dome papules', text: 'Molluscum contagiosum, especially in atopic skin or after pool exposure.' },
+      { label: 'Flexural itchy plaques with xerosis', text: 'Atopic dermatitis—ask about chronic itch, atopy, and sleep disruption.' },
+      { label: 'Diaper rash in folds with satellite pustules', text: 'Candida diaper dermatitis; start topical antifungal plus barrier care.' }
     ],
     answerSummary:
-      'Age-based distribution and border quality distinguish eczema from psoriasis or contact dermatitis.',
+      'Visual shortcuts—crusts, rings, burrows, and papule morphology—rapidly narrow pediatric dermatology differentials.',
     imageSearch: {
-      query: 'atopic dermatitis distribution flexural',
-      label: 'Search Google Images for eczema distribution'
+      query: 'pediatric dermatology impetigo tinea scabies molluscum candida diaper rash',
+      label: 'Search Google Images for pediatric rash clues'
     },
     explanation: [
-      'Atopic dermatitis migrates with age—extensors early, flexures later. Ill-defined margins and symmetry strengthen the diagnosis, while well-demarcated or unilateral plaques should prompt alternate considerations.'
+      'Teaching quick pattern recognition shortens time to treatment. Pair clues with confirmatory tests (KOH, scraping, cultures) when findings are atypical or therapy fails.'
     ],
     sources: [
       {
-        label: 'American Academy of Dermatology – Childhood eczema overview',
-        url: 'https://www.aad.org/public/diseases/eczema/childhood/atopic-dermatitis?utm_source=chatgpt.com'
+        label: 'American Academy of Dermatology – Pediatric Dermatology Atlas',
+        url: 'https://www.aad.org/member/education/pediatric-resources?utm_source=chatgpt.com'
       }
     ]
   }
@@ -36,6 +35,6 @@ const cards = [
 
 export default {
   id: 'pattern-clues',
-  label: 'Pattern insights',
+  label: 'Quick Differentials',
   cards
 };

--- a/projects/MediCards/PediatricDermatology/data/safety-net.js
+++ b/projects/MediCards/PediatricDermatology/data/safety-net.js
@@ -1,40 +1,104 @@
 const cards = [
   {
-    id: 'safety-net-red-flags',
-    title: 'Smart Safety Net',
-    shortLabel: 'Safety net',
+    id: 'red-flags-refer',
+    title: 'Red Flags → Refer',
+    shortLabel: 'Red flags',
     prompt: {
-      lead: 'Escalate when',
-      text: 'Which red flags demand urgent reassessment or referral?'
+      lead: 'Escalate fast',
+      text: 'Which findings mandate specialist referral for pediatric allergy/derm patients?'
     },
     answerPoints: [
-      { text: 'Fever, toxic appearance, or rapidly spreading cellulitis.' },
-      { text: 'Neonates with pustules—consider HSV, bacterial sepsis, impetigo, or congenital candidiasis.' },
-      { text: 'Periorbital swelling or visual changes from periocular hemangioma or impetigo complications.' },
-      { text: 'Extensive eczema unresponsive to appropriate potency steroids.' },
-      { text: 'Immunocompromised child, diagnostic uncertainty, or treatment failure.' }
+      { label: 'Anaphylaxis history', text: 'Any child with anaphylaxis or rapid multi-system reactions requires allergy referral for trigger clarification and emergency planning.' },
+      { label: 'Diagnostic uncertainty', text: 'Recurring rashes, wheeze, or suspected food allergy with unclear etiology should be co-managed to avoid missed systemic disease.' },
+      { label: 'Growth or nutrition impact', text: 'Failure to thrive or feeding aversion tied to suspected food allergy demands multidisciplinary assessment.' },
+      { label: 'Refractory disease', text: 'Severe eczema needing systemic therapy, poorly controlled asthma despite step-up treatment, or chronic urticaria unresponsive to high-dose antihistamines.' },
+      { label: 'High-risk procedures', text: 'Patients who may benefit from immunotherapy, oral food desensitization, or biologics.' }
     ],
     answerSummary:
-      'Systemic illness, ocular involvement, or refractory disease signals the need for urgent escalation.',
+      'Escalate care for anaphylaxis risk, unclear diagnoses, growth compromise, refractory disease, or when advanced therapies like immunotherapy are needed.',
     imageSearch: {
-      query: 'pediatric dermatology emergency signs',
-      label: 'Search Google Images for dermatology red flags'
+      query: 'pediatric allergy referral criteria anaphylaxis eczema asthma',
+      label: 'Search Google Images for pediatric allergy referral clues'
     },
     explanation: [
-      'Red-flag screening prevents missed invasive infections and vision-threatening hemangiomas. Neonates with pustules deserve rapid workup for HSV or bacterial sepsis, and any periocular swelling mandates ophthalmology evaluation.'
+      'Early subspecialty involvement optimizes safety and avoids unnecessary dietary restriction. Communicate current medications and previous reactions to streamline advanced testing or desensitization.'
     ],
     sources: [
       {
-        label: 'CDC – Clinical guidance for group A strep skin infections',
-        url: 'https://www.cdc.gov/group-a-strep/hcp/clinical-guidance/impetigo.html?utm_source=chatgpt.com'
+        label: 'AAAAI – Referral Guidelines for Allergic Disease',
+        url: 'https://www.aaaai.org/conditions-treatments/library/allergy-library/when-to-refer?utm_source=chatgpt.com'
       },
       {
-        label: 'AAP – Infantile hemangioma guideline',
-        url: 'https://publications.aap.org/pediatrics/article/143/1/e20183475/37268/Clinical-Practice-Guideline-for-the-Management-of?utm_source=chatgpt.com'
+        label: 'AAP – Atopic Dermatitis Treatment Escalation',
+        url: 'https://www.aap.org/en/patient-care/atopic-dermatitis/treatment-of-atopic-dermatitis/?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'urgent-ed-triggers',
+    title: 'When to Urgently Refer or Send to ED',
+    shortLabel: 'ED triggers',
+    prompt: {
+      lead: 'Red-alert scenarios',
+      text: 'Identify bedside clues that require emergency department transfer or urgent specialty input.'
+    },
+    answerPoints: [
+      { label: 'Rapidly spreading painful rash with fever', text: 'Suggests invasive infection (cellulitis, necrotizing fasciitis) or toxin-mediated disease—needs emergent evaluation.' },
+      { label: 'Suspected eczema herpeticum', text: 'Monomorphic punched-out vesicles/erosions, fever, or malaise in atopic skin—urgent antiviral therapy required.' },
+      { label: 'Progressive swelling with breathing difficulty', text: 'Anaphylaxis or airway edema—administer epinephrine and transfer to emergency care.' },
+      { label: 'Vesiculobullous lesions with mucosal involvement', text: 'Concern for Stevens–Johnson syndrome/toxic epidermal necrolysis—hospitalize immediately.' },
+      { label: 'Neonate (<28 days) with widespread vesicles/pustules or fever', text: 'Risk of disseminated HSV, bacterial sepsis, or Listeria—needs full sepsis workup.' }
+    ],
+    answerSummary:
+      'Painful febrile rashes, mucosal blistering, airway compromise, or neonatal vesicles demand emergency evaluation rather than outpatient follow-up.',
+    imageSearch: {
+      query: 'pediatric dermatology emergency eczema herpeticum stevens johnson',
+      label: 'Search Google Images for pediatric dermatology emergencies'
+    },
+    explanation: [
+      'Have low threshold to escalate when systemic symptoms accompany skin findings. Document timing, medications, and exposures to aid ED teams.'
+    ],
+    sources: [
+      {
+        label: 'American Academy of Dermatology – Dermatologic Emergencies',
+        url: 'https://www.aad.org/member/clinical-quality/guidelines/dermatologic-emergencies?utm_source=chatgpt.com'
       },
       {
-        label: 'AAAAI – Atopic dermatitis practice parameter',
-        url: 'https://www.aaaai.org/Aaaai/media/Media-Library-PDFs/Allergist%20Resources/Statements%20and%20Practice%20Parameters/JTF-Atopic-Dermatitis-Guideline-2023-07-31-2026.pdf?utm_source=chatgpt.com'
+        label: 'AAP Red Book – Eczema Herpeticum',
+        url: 'https://publications.aap.org/redbook/resources?utm_source=chatgpt.com'
+      }
+    ]
+  },
+  {
+    id: 'quick-doses',
+    title: 'Quick Doses: Epinephrine Autoinjectors',
+    shortLabel: 'Epinephrine doses',
+    prompt: {
+      lead: 'Dose check',
+      text: 'Which intramuscular epinephrine doses align with pediatric weight ranges?'
+    },
+    answerPoints: [
+      { label: 'Dose formula', text: '0.01 mg/kg of 1 mg/mL (1:1,000) solution administered IM in the mid-anterolateral thigh; typical max dose 0.3 mg for children.' },
+      { label: 'Autoinjector sizes', text: '0.1 mg (suitable for ~7.5–15 kg), 0.15 mg (≈15–30 kg), and 0.3 mg (≥30 kg). Use clinical judgment when a child falls between categories.' },
+      { label: 'Practical tips', text: 'Hold injector in place for full delivery per device instructions, follow with leg immobilization for 3–10 seconds, and call EMS after administration.' }
+    ],
+    answerSummary:
+      'Calculate epinephrine at 0.01 mg/kg and match autoinjector strengths to weight bands (0.1, 0.15, 0.3 mg) with prompt EMS activation after use.',
+    imageSearch: {
+      query: 'pediatric epinephrine autoinjector dosing 0.1 mg 0.15 mg 0.3 mg',
+      label: 'Search Google Images for epinephrine autoinjector dosing'
+    },
+    explanation: [
+      'Document weight at each visit to ensure correct device is prescribed. Families should always carry two autoinjectors in case symptoms persist or biphasic reactions occur.'
+    ],
+    sources: [
+      {
+        label: 'World Allergy Organization Anaphylaxis Guidelines',
+        url: 'https://www.worldallergy.org/resources/anaphylaxis?utm_source=chatgpt.com'
+      },
+      {
+        label: 'FDA – EpiPen Prescribing Information',
+        url: 'https://www.accessdata.fda.gov/drugsatfda_docs/label/2019/019430s086lbl.pdf?utm_source=chatgpt.com'
       }
     ]
   }
@@ -42,6 +106,6 @@ const cards = [
 
 export default {
   id: 'safety-net',
-  label: 'Safety net',
+  label: 'Safety Net & Dosing',
   cards
 };

--- a/projects/MediCards/PediatricDermatology/data/tests.js
+++ b/projects/MediCards/PediatricDermatology/data/tests.js
@@ -1,39 +1,40 @@
 const cards = [
   {
-    id: 'tests-quick-table',
-    title: 'Quick “Which Test?” Table',
-    shortLabel: 'Test selector',
+    id: 'testing-cliff-notes',
+    title: 'Testing Cliff Notes',
+    shortLabel: 'Testing cheatsheet',
     prompt: {
-      lead: 'Scenario',
-      text: 'Clinic triage requires targeted testing—what rapid tests align with each diagnosis?'
+      lead: 'Order wisely',
+      text: 'Which diagnostic tests actually change management in pediatric allergy and derm cases?'
     },
     answerPoints: [
-      { text: 'KOH prep for suspected tinea corporis or capitis.' },
-      { text: 'Bacterial culture for impetigo that is recurrent, associated with outbreaks, or not responding.' },
-      { text: 'Skin scraping or dermoscopy to confirm scabies when needed.' },
-      { text: 'No routine labs for classic AD, acne, pityriasis rosea, molluscum, or viral warts unless atypical or immunocompromised.' }
+      { label: 'Skin-prick tests / serum IgE', text: 'Order only when history suggests IgE-mediated allergy and results will change avoidance, immunotherapy, or desensitization plans; remember positive tests indicate sensitization, not clinical allergy.' },
+      { label: 'Oral food challenge', text: 'Gold standard for confirming or ruling out food allergy and assessing tolerance (e.g., baked milk/egg ladders); perform in supervised settings.' },
+      { label: 'Spirometry & FeNO', text: 'Use spirometry ≥5–6 years old to document reversible airflow obstruction; add FeNO when available to gauge type 2 inflammation and adherence.' },
+      { label: 'Patch testing', text: 'Evaluate persistent or unclear dermatitis for allergic contact triggers.' },
+      { label: 'Tryptase', text: 'Draw 1–3 hours after suspected anaphylaxis when diagnosis is uncertain or to evaluate for mast cell disorders.' }
     ],
     answerSummary:
-      'Match quick office tests to your differential and avoid unnecessary labs for classic inflammatory dermatoses.',
+      'Tie testing to history—reserve IgE studies, spirometry, patch testing, and tryptase for scenarios where results guide therapy, and use oral food challenges to confirm tolerance.',
     imageSearch: {
-      query: 'dermatology koh prep scabies scraping',
-      label: 'Search Google Images for bedside dermatology tests'
+      query: 'pediatric allergy testing skin prick spirometry patch test',
+      label: 'Search Google Images for pediatric allergy testing'
     },
     explanation: [
-      'Focused bedside diagnostics expedite therapy. KOH preps reveal branching hyphae, cultures tailor antibacterial therapy, and scrapings confirm mite infestations before undertaking extensive household treatment.'
+      'Avoid broad “screening” panels that detect sensitization without context. Document pre-test probability, counsel families on limitations, and plan follow-up to interpret results together.'
     ],
     sources: [
       {
-        label: 'AAFP – Diagnosis and management of tinea infections',
-        url: 'https://www.aafp.org/pubs/afp/issues/2014/1115/p702.html?utm_source=chatgpt.com'
+        label: 'AAAAI/ACAAI Food Allergy Diagnostic Guideline',
+        url: 'https://www.aaaai.org/practice-resources/statements-and-practice-parameters/food-allergy?utm_source=chatgpt.com'
       },
       {
-        label: 'CDC – Clinical guidance for impetigo',
-        url: 'https://www.cdc.gov/group-a-strep/hcp/clinical-guidance/impetigo.html?utm_source=chatgpt.com'
+        label: 'GINA 2023 – Lung Function Testing',
+        url: 'https://ginasthma.org/wp-content/uploads/2023/07/GINA-2023-Pocket-Guide-WMS.pdf?utm_source=chatgpt.com'
       },
       {
-        label: 'CDC – Clinical care of scabies',
-        url: 'https://www.cdc.gov/scabies/hcp/clinical-care/index.html?utm_source=chatgpt.com'
+        label: 'American Contact Dermatitis Society – Patch Testing',
+        url: 'https://www.contactderm.org/resources/pediatric?utm_source=chatgpt.com'
       }
     ]
   }
@@ -41,6 +42,6 @@ const cards = [
 
 export default {
   id: 'tests',
-  label: 'Diagnostic quick picks',
+  label: 'Testing Playbook',
   cards
 };

--- a/projects/MediCards/PediatricDermatology/deck-manifest.js
+++ b/projects/MediCards/PediatricDermatology/deck-manifest.js
@@ -1,9 +1,9 @@
-export const deckName = 'Pediatric Dermatology';
+export const deckName = 'Pediatric Allergy & Dermatology Toolkit';
 
 export const deckSections = [
-  { id: 'lesion-vocabulary', label: 'Lesion vocabulary', module: './data/lesion-vocabulary.js' },
-  { id: 'pattern-clues', label: 'Pattern insights', module: './data/patterns.js' },
-  { id: 'safety-net', label: 'Safety net', module: './data/safety-net.js' },
-  { id: 'tests', label: 'Diagnostic quick picks', module: './data/tests.js' },
-  { id: 'conditions', label: 'Condition playbooks', module: './data/conditions.js' }
+  { id: 'allergy-airway', label: 'Allergy & Airway Essentials', module: './data/lesion-vocabulary.js' },
+  { id: 'conditions', label: 'Condition Playbooks', module: './data/conditions.js' },
+  { id: 'pattern-clues', label: 'Quick Differentials', module: './data/patterns.js' },
+  { id: 'tests', label: 'Testing Playbook', module: './data/tests.js' },
+  { id: 'safety-net', label: 'Safety Net & Dosing', module: './data/safety-net.js' }
 ];

--- a/projects/MediCards/PediatricDermatology/pediatric-dermatology.js
+++ b/projects/MediCards/PediatricDermatology/pediatric-dermatology.js
@@ -44,7 +44,7 @@ export async function loadDeckData() {
   const sections = resolvedSections.filter(Boolean);
 
   if (!sections.length) {
-    throw new Error('No pediatric dermatology sections could be loaded.');
+    throw new Error('No pediatric allergy & dermatology sections could be loaded.');
   }
 
   const flattenedCards = sections.flatMap((section) => section.cards);


### PR DESCRIPTION
## Summary
- rebuild the allergy and airway section with detailed rhinitis, food allergy, anaphylaxis, asthma, and drug reaction cards
- expand the condition deck with updated management cards for eczema, infections, vascular lesions, and pigmentary disorders
- update quick differential, testing, and safety net cards plus refresh the deck manifest for the new pediatric allergy & dermatology toolkit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dbf77a9f188329ad863fe4daeee7b8