### PR TITLE
Clarify expertise learning loop

### DIFF
--- a/assets/css/personal-systems.css
+++ b/assets/css/personal-systems.css
@@ -317,41 +317,44 @@
     line-height: 1.6;
 }
 
-.loop-core {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    display: grid;
-    width: 146px;
-    height: 146px;
-    place-content: center;
-    border: 8px solid var(--systems-paper);
-    border-radius: 50%;
-    background: var(--systems-blue-deep);
-    box-shadow: 0 10px 28px rgba(23, 63, 114, 0.24);
-    color: #fff;
-    text-align: center;
-    transform: translate(-50%, -50%);
+.loop-condition:nth-child(even) {
+    text-align: right;
 }
 
-.loop-core::after {
-    position: absolute;
-    inset: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.42);
-    border-top-color: #fff;
-    border-radius: inherit;
-    content: "";
-    animation: loopOrbit 8s linear infinite;
+.loop-condition:nth-child(even) p {
+    margin-left: auto;
 }
 
-.loop-core span {
+.loop-cycle {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    padding: 18px 24px;
+    background: var(--systems-blue-pale);
+    color: var(--systems-blue-deep);
+}
+
+.loop-cycle small {
+    margin-right: 10px;
+    color: var(--systems-muted);
     font-size: 0.72rem;
+    font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
-.loop-core strong {
-    font-size: 1.18rem;
+.loop-cycle span,
+.loop-cycle strong,
+.loop-cycle i {
+    font-size: 0.82rem;
+    line-height: 1.2;
+}
+
+.loop-cycle i {
+    color: var(--systems-blue);
+    font-style: normal;
 }
 
 .loop-note {
@@ -553,12 +556,6 @@
     text-align: right;
 }
 
-@keyframes loopOrbit {
-    to {
-        transform: rotate(360deg);
-    }
-}
-
 @media (max-width: 880px) {
     .systems-title-grid {
         grid-template-columns: 1fr;
@@ -664,21 +661,15 @@
         margin-top: 24px;
     }
 
-    .loop-core {
-        position: relative;
-        top: auto;
-        left: auto;
-        width: 100%;
-        height: auto;
-        min-height: 100px;
-        border: 0;
-        border-radius: 0;
-        box-shadow: none;
-        transform: none;
+    .loop-cycle {
+        flex-wrap: wrap;
+        min-height: 92px;
     }
 
-    .loop-core::after {
-        display: none;
+    .loop-cycle small {
+        flex: 0 0 100%;
+        margin-right: 0;
+        text-align: center;
     }
 
     .failure-table,
@@ -742,11 +733,5 @@
 
     .systems-sources span {
         text-align: left;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .loop-core::after {
-        animation: none;
     }
 }

--- a/blog/expertise-is-a-system/index.html
+++ b/blog/expertise-is-a-system/index.html
@@ -127,9 +127,12 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
                                 <h3>Deliberate strain</h3>
                                 <p>Practice stays just beyond comfort, where attention is required and weaknesses cannot hide.</p>
                             </article>
-                            <div class="loop-core" aria-hidden="true">
+                            <div class="loop-cycle" aria-label="The learning cycle: recognize, choose, correct">
+                                <small>The learning cycle</small>
                                 <span>Recognize</span>
+                                <i aria-hidden="true">&rarr;</i>
                                 <strong>Choose</strong>
+                                <i aria-hidden="true">&rarr;</i>
                                 <span>Correct</span>
                             </div>
                         </div>

--- a/tests/finance-blog-test.js
+++ b/tests/finance-blog-test.js
@@ -107,6 +107,22 @@ async function run() {
         await assertNoClippedHeadings('Personal Systems desktop');
         assert.equal(await page.$$eval('.systems-roadmap a', (nodes) => nodes.length), 4);
         assert.equal(await page.$$eval('.loop-condition', (nodes) => nodes.length), 4);
+        const loopLayout = await page.evaluate(() => {
+            const conditions = [...document.querySelectorAll('.loop-condition')];
+            const cycle = document.querySelector('.loop-cycle');
+            return {
+                cycleTag: cycle.tagName,
+                cyclePosition: getComputedStyle(cycle).position,
+                cycleTop: cycle.getBoundingClientRect().top,
+                conditionBottom: Math.max(...conditions.map((node) => node.getBoundingClientRect().bottom)),
+                rightAlignment: [conditions[1], conditions[3]].map((node) => getComputedStyle(node).textAlign)
+            };
+        });
+        assert.equal(loopLayout.cycleTag, 'DIV');
+        assert.equal(loopLayout.cyclePosition, 'static');
+        assert.ok(loopLayout.cycleTop >= loopLayout.conditionBottom - 1);
+        assert.deepEqual(loopLayout.rightAlignment, ['right', 'right']);
+        assert.equal(await page.$$eval('.loop-core', (nodes) => nodes.length), 0);
         assert.equal(await page.$$eval('.failure-table tbody tr', (nodes) => nodes.length), 4);
         assert.equal(await page.$$eval('.practice-protocol li', (nodes) => nodes.length), 5);
         assert.match(await page.$eval('.systems-deck', (node) => node.textContent), /feedback system/i);


### PR DESCRIPTION
## Summary
- remove the overlapping circular control from the expertise diagram
- move the learning cycle into a non-interactive strip below the quadrants
- right-align Volume and Adaptation
- add regression assertions for overlap, alignment, and structure

## Validation
- npm test
- desktop and mobile element screenshots