### PR TITLE
Refine expertise system summary

### DIFF
--- a/assets/css/personal-systems.css
+++ b/assets/css/personal-systems.css
@@ -80,34 +80,67 @@
 
 .expertise-equation {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    counter-reset: condition;
     border-top: 1px solid var(--systems-ink);
     color: var(--systems-ink);
 }
 
+.expertise-equation::before {
+    grid-column: 1 / -1;
+    padding: 12px 0 10px;
+    border-bottom: 1px solid var(--systems-line);
+    color: var(--systems-blue);
+    content: "The expertise system";
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
 .expertise-equation span {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    padding: 12px 0;
+    display: grid;
+    grid-template-columns: 26px minmax(0, 1fr);
+    gap: 8px;
+    align-items: baseline;
+    padding: 14px 12px 14px 0;
     border-bottom: 1px solid var(--systems-line);
     font-size: 0.86rem;
     font-weight: 700;
 }
 
+.expertise-equation span:nth-of-type(even) {
+    padding-right: 0;
+    padding-left: 12px;
+    border-left: 1px solid var(--systems-line);
+}
+
 .expertise-equation span::before {
-    width: 6px;
-    height: 6px;
-    flex: 0 0 6px;
-    background: var(--systems-blue);
-    content: "";
+    color: var(--systems-blue);
+    content: counter(condition, decimal-leading-zero);
+    counter-increment: condition;
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+}
+
+.expertise-equation i {
+    display: none;
 }
 
 .expertise-equation strong {
-    padding-top: 18px;
+    grid-column: 1 / -1;
+    padding-top: 16px;
+    color: var(--systems-muted);
+    font-size: 0.92rem;
+    font-weight: 600;
+    line-height: 1.5;
+    text-align: left;
+}
+
+.expertise-equation strong em {
     color: var(--systems-green);
-    font-size: 1.25rem;
-    text-align: right;
+    font-size: 1.05rem;
+    font-style: normal;
 }
 
 .systems-layout {

--- a/blog/expertise-is-a-system/index.html
+++ b/blog/expertise-is-a-system/index.html
@@ -15,7 +15,7 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
     <link rel="icon" type="image/png" href="../../assets/favicon.png">
     <link rel="stylesheet" href="../../assets/css/style.css">
     <link rel="stylesheet" href="../../assets/css/blog.css">
-    <link rel="stylesheet" href="../../assets/css/personal-systems.css">
+    <link rel="stylesheet" href="../../assets/css/personal-systems.css?v=8304233">
 </head>
 <body class="blog-article personal-systems-page">
     <header class="topbar">
@@ -57,7 +57,7 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
                         <span>Repeated attempts</span>
                         <span>Timely feedback</span>
                         <span>Deliberate strain</span>
-                        <strong>= expertise</strong>
+                        <strong>All four work together to produce <em>expertise</em>.</strong>
                     </div>
                 </div>
             </header>

--- a/tests/finance-blog-test.js
+++ b/tests/finance-blog-test.js
@@ -123,6 +123,8 @@ async function run() {
         await page.waitForSelector('.practice-loop');
         await assertNoClippedHeadings('Personal Systems desktop');
         assert.equal(await page.$$eval('.expertise-equation i', (nodes) => nodes.length), 0);
+        assert.equal(await page.$$eval('.expertise-equation span', (nodes) => nodes.length), 4);
+        assert.match(await page.$eval('.expertise-equation strong', (node) => node.textContent), /all four work together/i);
         assert.equal(await page.$$eval('.systems-roadmap a', (nodes) => nodes.length), 4);
         assert.equal(await page.$$eval('.loop-condition', (nodes) => nodes.length), 4);
         const loopLayout = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- replace the awkward equation with a numbered four-condition model
- remove all math and expand-control cues
- add cache-busting for the article stylesheet
- keep legacy plus elements hidden during mixed-cache loads

## Tests
- npm test -- --runInBand