### PR TITLE
Focus expertise article hierarchy

### DIFF
--- a/assets/css/personal-systems.css
+++ b/assets/css/personal-systems.css
@@ -19,11 +19,16 @@
 .systems-article {
     width: min(1180px, calc(100% - 48px));
     margin: 0 auto;
-    padding: 108px 0 80px;
+    padding: 60px 0 80px;
 }
 
 .systems-hero {
-    padding-bottom: 38px;
+    display: flex;
+    min-height: calc(100svh - 60px);
+    box-sizing: border-box;
+    flex-direction: column;
+    justify-content: center;
+    padding: clamp(52px, 8vh, 84px) 0;
     border-bottom: 2px solid var(--systems-ink);
 }
 
@@ -53,10 +58,7 @@
 }
 
 .systems-title-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.4fr) minmax(290px, 0.6fr);
-    gap: clamp(44px, 8vw, 100px);
-    align-items: end;
+    display: block;
 }
 
 .systems-title-grid h1 {
@@ -78,69 +80,9 @@
     line-height: 1.65;
 }
 
-.expertise-equation {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    counter-reset: condition;
-    border-top: 1px solid var(--systems-ink);
-    color: var(--systems-ink);
-}
-
-.expertise-equation::before {
-    grid-column: 1 / -1;
-    padding: 12px 0 10px;
-    border-bottom: 1px solid var(--systems-line);
-    color: var(--systems-blue);
-    content: "The expertise system";
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.expertise-equation span {
-    display: grid;
-    grid-template-columns: 26px minmax(0, 1fr);
-    gap: 8px;
-    align-items: baseline;
-    padding: 14px 12px 14px 0;
-    border-bottom: 1px solid var(--systems-line);
-    font-size: 0.86rem;
-    font-weight: 700;
-}
-
-.expertise-equation span:nth-of-type(even) {
-    padding-right: 0;
-    padding-left: 12px;
-    border-left: 1px solid var(--systems-line);
-}
-
-.expertise-equation span::before {
-    color: var(--systems-blue);
-    content: counter(condition, decimal-leading-zero);
-    counter-increment: condition;
-    font-size: 0.68rem;
-    letter-spacing: 0.04em;
-}
-
-.expertise-equation i {
+.expertise-equation,
+.systems-roadmap {
     display: none;
-}
-
-.expertise-equation strong {
-    grid-column: 1 / -1;
-    padding-top: 16px;
-    color: var(--systems-muted);
-    font-size: 0.92rem;
-    font-weight: 600;
-    line-height: 1.5;
-    text-align: left;
-}
-
-.expertise-equation strong em {
-    color: var(--systems-green);
-    font-size: 1.05rem;
-    font-style: normal;
 }
 
 .systems-layout {
@@ -148,52 +90,7 @@
     grid-template-columns: 190px minmax(0, 760px);
     gap: clamp(42px, 8vw, 100px);
     justify-content: center;
-    padding-top: 64px;
-}
-
-.systems-roadmap {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    border-bottom: 1px solid var(--systems-ink);
-}
-
-.systems-roadmap a {
-    display: grid;
-    gap: 6px;
-    min-width: 0;
-    padding: 22px 20px 24px 0;
-    color: var(--systems-ink);
-    text-decoration: none;
-}
-
-.systems-roadmap a + a {
-    padding-left: 20px;
-    border-left: 1px solid var(--systems-line);
-}
-
-.systems-roadmap span {
-    color: var(--systems-blue);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.systems-roadmap strong {
-    font-size: 1.2rem;
-    line-height: 1.2;
-}
-
-.systems-roadmap small {
-    color: var(--systems-muted);
-    font-size: 0.82rem;
-    line-height: 1.45;
-}
-
-.systems-roadmap a:hover,
-.systems-roadmap a:focus-visible {
-    background: #fff;
-    color: var(--systems-blue);
+    padding-top: clamp(72px, 11vh, 112px);
 }
 
 .systems-rail {
@@ -234,11 +131,11 @@
 
 .systems-section {
     scroll-margin-top: 92px;
-    padding: 82px 0 0;
+    margin-top: clamp(104px, 14vh, 144px);
 }
 
 .systems-section:first-child {
-    padding-top: 0;
+    margin-top: 0;
 }
 
 .systems-section p {
@@ -311,91 +208,48 @@
 }
 
 .practice-loop {
-    position: relative;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1px;
-    overflow: hidden;
     margin: 42px 0 28px;
-    border: 1px solid var(--systems-line);
-    background: var(--systems-line);
+    padding: 0;
+    border-top: 2px solid var(--systems-ink);
+    list-style: none;
 }
 
 .loop-condition {
-    min-height: 230px;
-    padding: 30px;
-    background: #fff;
+    display: grid;
+    grid-template-columns: 52px minmax(180px, 0.7fr) minmax(280px, 1.3fr);
+    gap: 24px;
+    align-items: baseline;
+    padding: 24px 0;
+    border-bottom: 1px solid var(--systems-line);
 }
 
 .loop-condition span {
     color: var(--systems-blue);
-    font-size: 0.7rem;
+    font-size: 0.76rem;
     font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
+    letter-spacing: 0.06em;
 }
 
 .loop-condition h3 {
-    margin: 46px 0 12px;
+    margin: 0;
     color: var(--systems-ink);
-    font-size: 1.2rem;
+    font-size: 1.12rem;
     letter-spacing: -0.025em;
 }
 
 .loop-condition p {
-    max-width: 34ch;
     margin: 0;
     color: var(--systems-muted);
-    font-size: 0.82rem;
-    line-height: 1.6;
-}
-
-.loop-condition:nth-child(even) {
-    text-align: right;
-}
-
-.loop-condition:nth-child(even) p {
-    margin-left: auto;
-}
-
-.loop-cycle {
-    grid-column: 1 / -1;
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    justify-content: center;
-    padding: 18px 24px;
-    background: var(--systems-blue-pale);
-    color: var(--systems-blue-deep);
-}
-
-.loop-cycle small {
-    margin-right: 10px;
-    color: var(--systems-muted);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.loop-cycle span,
-.loop-cycle strong,
-.loop-cycle i {
-    font-size: 0.82rem;
-    line-height: 1.2;
-}
-
-.loop-cycle i {
-    color: var(--systems-blue);
-    font-style: normal;
+    font-size: 0.9rem;
+    line-height: 1.65;
 }
 
 .loop-note {
-    padding: 22px 24px;
+    max-width: 62ch;
+    margin-top: 28px;
+    padding-top: 22px;
     border-top: 1px solid var(--systems-green);
-    border-bottom: 1px solid var(--systems-green);
-    background: var(--systems-green-pale);
-    color: #205f40 !important;
+    color: var(--systems-ink) !important;
     font-size: 0.98rem !important;
 }
 
@@ -444,17 +298,21 @@
 
 .case-notes {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 26px;
+    grid-template-columns: 1fr;
     margin-top: 38px;
+    border-bottom: 1px solid var(--systems-line);
 }
 
 .case-notes article {
-    padding-top: 16px;
-    border-top: 1px solid var(--systems-red);
+    display: grid;
+    grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1.2fr);
+    gap: 28px;
+    padding: 24px 0;
+    border-top: 1px solid var(--systems-line);
 }
 
 .case-notes h3 {
+    margin: 0;
     color: var(--systems-ink);
     font-size: 1rem;
     line-height: 1.25;
@@ -462,9 +320,10 @@
 }
 
 .case-notes p {
+    margin: 0;
     color: var(--systems-muted);
-    font-size: 0.84rem;
-    line-height: 1.62;
+    font-size: 0.9rem;
+    line-height: 1.65;
 }
 
 .practice-protocol {
@@ -628,51 +487,19 @@
 }
 
 @media (max-width: 880px) {
-    .systems-title-grid {
-        grid-template-columns: 1fr;
-        gap: 42px;
-    }
-
-    .expertise-equation {
-        max-width: 520px;
-    }
-
     .systems-layout {
         grid-template-columns: 1fr;
     }
 
     .systems-rail {
-        position: static;
-        grid-template-columns: repeat(3, 1fr);
-    }
-
-    .systems-roadmap {
-        grid-template-columns: 1fr 1fr;
-    }
-
-    .systems-roadmap a:nth-child(3) {
-        padding-left: 0;
-        border-top: 1px solid var(--systems-line);
-        border-left: 0;
-    }
-
-    .systems-roadmap a:nth-child(4) {
-        border-top: 1px solid var(--systems-line);
-    }
-
-    .systems-rail span {
-        grid-column: 1 / -1;
-    }
-
-    .systems-rail a {
-        padding-right: 12px;
+        display: none;
     }
 }
 
 @media (max-width: 700px) {
     .systems-article {
         width: min(100% - 32px, 1180px);
-        padding-top: 92px;
+        padding-top: 60px;
     }
 
     .systems-meta {
@@ -684,63 +511,37 @@
         font-size: clamp(3rem, 16vw, 4.6rem);
     }
 
-    .systems-rail,
     .systems-heading,
-    .practice-loop,
     .case-notes {
         grid-template-columns: 1fr;
-    }
-
-    .systems-rail {
-        gap: 0 12px;
     }
 
     .systems-heading {
         align-items: start;
     }
 
-    .systems-roadmap {
-        grid-template-columns: 1fr;
-    }
-
-    .systems-roadmap a,
-    .systems-roadmap a + a,
-    .systems-roadmap a:nth-child(3) {
-        padding: 16px 4px;
-        border-top: 1px solid var(--systems-line);
-        border-left: 0;
-    }
-
-    .systems-roadmap a:first-child {
-        border-top: 0;
+    .systems-layout {
+        padding-top: 72px;
     }
 
     .practice-loop {
-        overflow: visible;
-        gap: 0;
-        border-bottom: 0;
-        background: transparent;
+        margin-top: 34px;
     }
 
     .loop-condition {
-        min-height: auto;
-        padding: 26px 22px;
-        border-bottom: 1px solid var(--systems-line);
+        grid-template-columns: 34px minmax(0, 1fr);
+        gap: 8px 12px;
+        align-items: baseline;
+        padding: 22px 0;
     }
 
-    .loop-condition h3 {
-        margin-top: 24px;
+    .loop-condition p {
+        grid-column: 2;
     }
 
-    .loop-cycle {
-        flex-wrap: wrap;
-        min-height: 92px;
-    }
-
-    .loop-cycle small {
-        flex: 0 0 100%;
-        margin-right: 0;
-        text-align: center;
+    .case-notes article {
+        grid-template-columns: 1fr;
+        gap: 10px;
     }
 
     .failure-table,

--- a/blog/expertise-is-a-system/index.html
+++ b/blog/expertise-is-a-system/index.html
@@ -15,7 +15,7 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
     <link rel="icon" type="image/png" href="../../assets/favicon.png">
     <link rel="stylesheet" href="../../assets/css/style.css">
     <link rel="stylesheet" href="../../assets/css/blog.css">
-    <link rel="stylesheet" href="../../assets/css/personal-systems.css?v=8304233">
+    <link rel="stylesheet" href="../../assets/css/personal-systems.css?v=8304234">
 </head>
 <body class="blog-article personal-systems-page">
     <header class="topbar">
@@ -48,26 +48,10 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
                     <span>9 minute read</span>
                 </div>
                 <div class="systems-title-grid">
-                    <div>
-                        <h1>Expertise is a system, not a trait</h1>
-                        <p class="systems-deck">Ten thousand hours is only elapsed time. Expertise appears when those hours run through a feedback system built from valid patterns, repeated attempts, timely correction, and deliberate strain.</p>
-                    </div>
-                    <div class="expertise-equation" aria-label="Expertise requires valid patterns, repeated attempts, timely feedback, and deliberate strain">
-                        <span>Valid patterns</span>
-                        <span>Repeated attempts</span>
-                        <span>Timely feedback</span>
-                        <span>Deliberate strain</span>
-                        <strong>All four work together to produce <em>expertise</em>.</strong>
-                    </div>
+                    <h1>Expertise is a system, not a trait</h1>
+                    <p class="systems-deck">Ten thousand hours is only elapsed time. Expertise appears when those hours run through a feedback system built from valid patterns, repeated attempts, timely correction, and deliberate strain.</p>
                 </div>
             </header>
-
-            <nav class="systems-roadmap" aria-label="What this article delivers">
-                <a href="#recognition"><span>First</span><strong>Recognize</strong><small>See why expert memory is narrow, not magical.</small></a>
-                <a href="#loop"><span>Then</span><strong>Build</strong><small>Learn the four conditions that create intuition.</small></a>
-                <a href="#breaks"><span>Test</span><strong>Diagnose</strong><small>Spot experience that produces false confidence.</small></a>
-                <a href="#protocol"><span>Apply</span><strong>Practice</strong><small>Turn the research into a repeatable system.</small></a>
-            </nav>
 
             <div class="systems-layout">
                 <aside class="systems-rail" aria-label="Article sections">
@@ -76,6 +60,7 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
                     <a href="#loop">The four-part loop</a>
                     <a href="#breaks">Where it breaks</a>
                     <a href="#protocol">Build your system</a>
+                    <a href="#audit">Audit your practice</a>
                     <a href="#hours">Beyond 10,000 hours</a>
                     <a href="#sources">Sources</a>
                 </aside>
@@ -103,36 +88,28 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
                             <p><strong>Key point:</strong> Time only teaches when four conditions work together. Remove one and the loop stops producing reliable intuition.</p>
                         </div>
 
-                        <div class="practice-loop" role="list" aria-label="Four conditions for expertise">
-                            <article class="loop-condition" role="listitem">
-                                <span>Input</span>
+                        <ol class="practice-loop" aria-label="Four conditions for expertise">
+                            <li class="loop-condition">
+                                <span aria-hidden="true">01</span>
                                 <h3>Valid patterns</h3>
-                                <p>The environment contains regularities that can actually be learned. Chess has structure. Roulette does not.</p>
-                            </article>
-                            <article class="loop-condition" role="listitem">
-                                <span>Volume</span>
+                                <p>Start with an environment that contains regularities worth learning. Chess has structure. Roulette does not.</p>
+                            </li>
+                            <li class="loop-condition">
+                                <span aria-hidden="true">02</span>
                                 <h3>Repeated attempts</h3>
-                                <p>You face the same class of problem often enough to compare choices across many outcomes.</p>
-                            </article>
-                            <article class="loop-condition" role="listitem">
-                                <span>Correction</span>
+                                <p>Face the same class of decision often enough to compare choices across many outcomes.</p>
+                            </li>
+                            <li class="loop-condition">
+                                <span aria-hidden="true">03</span>
                                 <h3>Timely feedback</h3>
-                                <p>The result arrives soon enough, and clearly enough, to connect what you did with what happened.</p>
-                            </article>
-                            <article class="loop-condition" role="listitem">
-                                <span>Adaptation</span>
+                                <p>Connect each decision to its result while the reasoning behind it is still clear.</p>
+                            </li>
+                            <li class="loop-condition">
+                                <span aria-hidden="true">04</span>
                                 <h3>Deliberate strain</h3>
-                                <p>Practice stays just beyond comfort, where attention is required and weaknesses cannot hide.</p>
-                            </article>
-                            <div class="loop-cycle" aria-label="The learning cycle: recognize, choose, correct">
-                                <small>The learning cycle</small>
-                                <span>Recognize</span>
-                                <i aria-hidden="true">&rarr;</i>
-                                <strong>Choose</strong>
-                                <i aria-hidden="true">&rarr;</i>
-                                <span>Correct</span>
-                            </div>
-                        </div>
+                                <p>Use each correction to raise the challenge just beyond comfort, where weaknesses cannot hide.</p>
+                            </li>
+                        </ol>
 
                         <p class="loop-note"><strong>The conditions multiply; they do not merely add.</strong> Thousands of clear outcomes in a random environment teach superstition. Thousands of comfortable repetitions in a valid environment preserve competence without extending it.</p>
                     </section>
@@ -222,9 +199,15 @@ FORM: Feedback-loop field guide, fifth grounded structure, equation-and-diagnost
                             </li>
                         </ol>
 
+                    </section>
+
+                    <section class="systems-section audit-section" id="audit">
+                        <div class="systems-heading">
+                            <h2>Audit your practice</h2>
+                            <p><strong>Key point:</strong> Find the missing condition before you add more time.</p>
+                        </div>
                         <div class="system-audit">
-                            <h3>A five-minute audit</h3>
-                            <p>Pick one skill you care about and answer these questions plainly.</p>
+                            <p>Pick one skill you care about and answer these four questions plainly.</p>
                             <ul>
                                 <li>Does this environment contain patterns, or am I mostly navigating randomness?</li>
                                 <li>Can I repeat the same kind of decision often enough to compare outcomes?</li>

--- a/tests/finance-blog-test.js
+++ b/tests/finance-blog-test.js
@@ -122,29 +122,14 @@ async function run() {
         await page.waitForFunction(() => window.location.pathname.includes('/blog/expertise-is-a-system/'));
         await page.waitForSelector('.practice-loop');
         await assertNoClippedHeadings('Personal Systems desktop');
-        assert.equal(await page.$$eval('.expertise-equation i', (nodes) => nodes.length), 0);
-        assert.equal(await page.$$eval('.expertise-equation span', (nodes) => nodes.length), 4);
-        assert.match(await page.$eval('.expertise-equation strong', (node) => node.textContent), /all four work together/i);
-        assert.equal(await page.$$eval('.systems-roadmap a', (nodes) => nodes.length), 4);
+        assert.equal(await page.$$eval('.expertise-equation, .systems-roadmap', (nodes) => nodes.length), 0);
+        assert.ok(await page.$eval('.systems-hero', (hero) => hero.getBoundingClientRect().height >= window.innerHeight - 80));
         assert.equal(await page.$$eval('.loop-condition', (nodes) => nodes.length), 4);
-        const loopLayout = await page.evaluate(() => {
-            const conditions = [...document.querySelectorAll('.loop-condition')];
-            const cycle = document.querySelector('.loop-cycle');
-            return {
-                cycleTag: cycle.tagName,
-                cyclePosition: getComputedStyle(cycle).position,
-                cycleTop: cycle.getBoundingClientRect().top,
-                conditionBottom: Math.max(...conditions.map((node) => node.getBoundingClientRect().bottom)),
-                rightAlignment: [conditions[1], conditions[3]].map((node) => getComputedStyle(node).textAlign)
-            };
-        });
-        assert.equal(loopLayout.cycleTag, 'DIV');
-        assert.equal(loopLayout.cyclePosition, 'static');
-        assert.ok(loopLayout.cycleTop >= loopLayout.conditionBottom - 1);
-        assert.deepEqual(loopLayout.rightAlignment, ['right', 'right']);
-        assert.equal(await page.$$eval('.loop-core', (nodes) => nodes.length), 0);
+        assert.equal(await page.$eval('.practice-loop', (node) => node.tagName), 'OL');
+        assert.equal(await page.$$eval('.loop-cycle, .loop-core', (nodes) => nodes.length), 0);
         assert.equal(await page.$$eval('.failure-table tbody tr', (nodes) => nodes.length), 4);
         assert.equal(await page.$$eval('.practice-protocol li', (nodes) => nodes.length), 5);
+        assert.equal(await page.$eval('.system-audit', (node) => node.closest('section').id), 'audit');
         assert.equal(await page.$eval('.video-credit', (link) => link.href), 'https://www.youtube.com/watch?v=5eW6Eagr9XA');
         assert.match(await page.$eval('.video-credit', (link) => link.textContent), /the expert myth/i);
         assert.match(await page.$eval('.video-credit', (link) => link.textContent), /veritasium/i);
@@ -155,10 +140,10 @@ async function run() {
         const systemsDimensions = await page.evaluate(() => ({
             clientWidth: document.documentElement.clientWidth,
             scrollWidth: document.documentElement.scrollWidth,
-            loopColumns: getComputedStyle(document.querySelector('.practice-loop')).gridTemplateColumns.split(' ').length
+            railDisplay: getComputedStyle(document.querySelector('.systems-rail')).display
         }));
         assert.ok(systemsDimensions.scrollWidth <= systemsDimensions.clientWidth, `Personal Systems mobile overflow: ${systemsDimensions.scrollWidth}px > ${systemsDimensions.clientWidth}px`);
-        assert.equal(systemsDimensions.loopColumns, 1);
+        assert.equal(systemsDimensions.railDisplay, 'none');
         await assertNoClippedHeadings('Personal Systems mobile');
         await page.setViewport({ width: 1280, height: 900, deviceScaleFactor: 1 });
 


### PR DESCRIPTION
## Summary
- reduce the opening to one focal argument per viewport
- remove the redundant hero model and roadmap
- replace the decorative quadrant with a meaningful four-step sequence
- separate the practice procedure from the self-audit
- flatten supporting case notes and correct anchor landing positions

## Tests
- npm test -- --runInBand
- impeccable layout detector