### PR TITLE
Update Amazon post-earnings market data

### DIFF
--- a/assets/js/finance.js
+++ b/assets/js/finance.js
@@ -95,26 +95,26 @@
         },
         marketMove: {
             title: 'Post-earnings stock move',
-            summary: 'Microsoft received the strongest response. Meta and Alphabet sold off, while Amazon\'s next-session response remains pending.',
-            values: [15.5, -8.0, -7.1, null],
-            displays: ['+15.5%', '−8.0%', '−7.1%', 'Pending'],
+            summary: 'Microsoft and Amazon received similarly strong responses, while Meta and Alphabet sold off.',
+            values: [15.5, -8.0, -7.1, 15.3],
+            displays: ['+15.5%', '−8.0%', '−7.1%', '+15.3%'],
             notes: [
                 'July 30 close of $451.10 versus $390.54 on July 29.',
                 'July 30 close of $539.03 versus $585.61 on July 29.',
                 'July 23 close of $317.69 versus $342.09 on July 22.',
-                'Amazon released after the July 30 close; the July 31 response is not yet available.'
+                'July 31 close of $271.58 versus $235.50 on July 30.'
             ]
         },
         trailingPe: {
             title: 'Trailing price-to-earnings ratio',
-            summary: 'Microsoft carried the highest reported P/E. Alphabet looked cheaper on reported earnings, but its denominator includes a large investment gain; Amazon remains pending.',
-            values: [25.1, 21.3, 15.9, null],
-            displays: ['25.1×', '21.3×', '15.9×', 'Pending'],
+            summary: 'Microsoft carried the highest reported P/E. Alphabet looked cheaper on reported earnings, but both Alphabet and Amazon include large investment gains in the denominator.',
+            values: [25.1, 21.3, 15.9, 21.8],
+            displays: ['25.1×', '21.3×', '15.9×', '21.8×'],
             notes: [
                 'July 30 price divided by $17.95 of reported trailing EPS.',
                 'Reported trailing P/E as of July 30.',
                 'July 23 price divided by $19.93 of reported trailing EPS; the $99B pre-tax equity gain lowers this multiple.',
-                'Amazon\'s post-release price and trailing P/E remain pending.'
+                'July 31 price divided by $12.44 of reported trailing EPS; the $79.8B trailing non-operating gain lowers this multiple.'
             ]
         }
     };

--- a/blog/ai-capex-reckoning/index.html
+++ b/blog/ai-capex-reckoning/index.html
@@ -126,11 +126,11 @@ FORM: Capital allocation scanner, fourth grounded structure, Composition C stagi
                                     </tr>
                                     <tr>
                                         <th scope="row"><button type="button" data-metric="marketMove">Post-earnings move</button></th>
-                                        <td class="metric-positive">+15.5% <span class="rank-badge">High</span></td><td class="metric-negative">−8.0% <span class="rank-badge is-low">Low</span></td><td class="metric-negative">−7.1%</td><td>Pending</td>
+                                        <td class="metric-positive">+15.5% <span class="rank-badge">High</span></td><td class="metric-negative">−8.0% <span class="rank-badge is-low">Low</span></td><td class="metric-negative">−7.1%</td><td class="metric-positive">+15.3%</td>
                                     </tr>
                                     <tr>
                                         <th scope="row"><button type="button" data-metric="trailingPe">Trailing P/E</button></th>
-                                        <td>25.1× <span class="rank-badge">High</span></td><td>21.3×</td><td>15.9× <span class="rank-badge is-low">Low</span></td><td>Pending</td>
+                                        <td>25.1× <span class="rank-badge">High</span></td><td>21.3×</td><td>15.9× <span class="rank-badge is-low">Low</span></td><td>21.8×<sup>†</sup></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -278,7 +278,7 @@ FORM: Capital allocation scanner, fourth grounded structure, Composition C stagi
                                     <tr><th>Microsoft <span>MSFT · Jul 29, after close</span></th><td><span class="market-date">Jul 29</span>$390.54</td><td><span class="market-date">Jul 30</span>$451.10</td><td class="metric-positive">+15.5% <span class="rank-badge">High</span></td><td>25.1×</td><td>50.0×</td></tr>
                                     <tr><th>Meta <span>META · Jul 29, after close</span></th><td><span class="market-date">Jul 29</span>$585.61</td><td><span class="market-date">Jul 30</span>$539.03</td><td class="metric-negative">−8.0% <span class="rank-badge is-low">Low</span></td><td>21.3×</td><td>33.1×</td></tr>
                                     <tr><th>Alphabet <span>GOOGL · Jul 22, after close</span></th><td><span class="market-date">Jul 22</span>$342.09</td><td><span class="market-date">Jul 23</span>$317.69</td><td class="metric-negative">−7.1%</td><td>15.9×<sup>†</sup></td><td>72.9×</td></tr>
-                                    <tr><th>Amazon <span>AMZN · Jul 30, after close</span></th><td><span class="market-date">Jul 30</span>$235.50</td><td><span class="market-date">Jul 31</span>Pending</td><td>Pending</td><td>Pending</td><td>N/M<sup>‡</sup></td></tr>
+                                    <tr><th>Amazon <span>AMZN · Jul 30, after close</span></th><td><span class="market-date">Jul 30</span>$235.50</td><td><span class="market-date">Jul 31</span>$271.58</td><td class="metric-positive">+15.3%</td><td>21.8×<sup>†</sup></td><td>N/M<sup>‡</sup></td></tr>
                                 </tbody>
                             </table>
                         </div>
@@ -319,7 +319,7 @@ FORM: Capital allocation scanner, fourth grounded structure, Composition C stagi
                         </details>
                         <details>
                             <summary>How market moves and valuation multiples were calculated</summary>
-                            <p>For each company, the event return compares the close on its earnings-release date with the next regular-session close because all four releases occurred after hours. Alphabet uses July 22–23; Microsoft and Meta use July 29–30. Amazon released after the July 30 close, so its July 31 response and post-release multiples remain pending. P/E divides the next-session close by reported trailing diluted EPS; P/FCF uses trailing free cash flow per share.</p>
+                            <p>For each company, the event return compares the close on its earnings-release date with the next regular-session close because all four releases occurred after hours. Alphabet uses July 22–23; Microsoft and Meta use July 29–30; Amazon uses July 30–31. P/E divides the next-session close by reported trailing diluted EPS; P/FCF uses trailing free cash flow per share.</p>
                         </details>
                     </section>
 
@@ -335,6 +335,7 @@ FORM: Capital allocation scanner, fourth grounded structure, Composition C stagi
                             <li><a href="https://ir.aboutamazon.com/news-release/news-release-details/2026/Amazon-com-Announces-Second-Quarter-Results/" target="_blank" rel="noopener noreferrer">Amazon Q2 2026 earnings release <span>Investor Relations ↗</span></a></li>
                             <li><a href="https://finance.yahoo.com/quotes/MSFT,META,GOOGL,AMZN/" target="_blank" rel="noopener noreferrer">Company-specific pre-release and next-session closing prices <span>Yahoo Finance ↗</span></a></li>
                             <li><a href="https://stockanalysis.com/stocks/msft/statistics/" target="_blank" rel="noopener noreferrer">Trailing EPS, free cash flow, and valuation inputs <span>Stock Analysis ↗</span></a></li>
+                            <li><a href="https://stockanalysis.com/stocks/amzn/statistics/" target="_blank" rel="noopener noreferrer">Amazon trailing EPS and valuation inputs <span>Stock Analysis ↗</span></a></li>
                         </ol>
                     </section>
                 </main>
@@ -348,7 +349,7 @@ FORM: Capital allocation scanner, fourth grounded structure, Composition C stagi
 
     <script src="../../assets/js/data.js"></script>
     <script src="../../assets/js/main.js"></script>
-    <script src="../../assets/js/finance.js"></script>
+    <script src="../../assets/js/finance.js?v=8304235"></script>
     <script>window.initFinanceArticle && window.initFinanceArticle();</script>
 </body>
 </html>

--- a/tests/finance-blog-test.js
+++ b/tests/finance-blog-test.js
@@ -270,9 +270,12 @@ async function run() {
         await page.click('[data-metric="marketMove"]');
         await page.waitForFunction(() => document.getElementById('expanded-title').textContent === 'Post-earnings stock move');
         const marketMoves = await page.$$eval('.value-mark', (nodes) => nodes.map((node) => node.childNodes[0].textContent));
-        assert.deepEqual(marketMoves, ['+15.5%', '−8.0%', '−7.1%', 'Pending']);
+        assert.deepEqual(marketMoves, ['+15.5%', '−8.0%', '−7.1%', '+15.3%']);
         assert.match(await page.$eval('.market-table tbody tr:nth-child(3)', (node) => node.textContent), /jul 22/i);
-        assert.match(await page.$eval('.market-table tbody tr:nth-child(4)', (node) => node.textContent), /pending/i);
+        const amazonMarketRow = await page.$eval('.market-table tbody tr:nth-child(4)', (node) => node.textContent);
+        assert.match(amazonMarketRow, /\$271\.58/);
+        assert.match(amazonMarketRow, /\+15\.3%/);
+        assert.match(amazonMarketRow, /21\.8×/);
 
         await page.click('[data-metric="freeCashFlow"]');
         const signedDirection = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- replace Amazon's pending July 31 market data with the .58 close
- calculate the +15.3% next-session response and 21.8x trailing P/E
- update the interactive metric views, methodology, and source list
- extend browser coverage for the completed Amazon row

## Tests
- npm test -- --runInBand